### PR TITLE
Add limit plugin for live API usage display

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 A collection of productivity plugins for Claude Code.
 
+## Requirements
+
+All plugins require:
+- `jq` - JSON processor (install: `sudo apt install jq`)
+
 ## Installation
 
 Add this marketplace to Claude Code:
@@ -14,6 +19,18 @@ Or within a Claude session:
 ```
 /plugin marketplace add Marcel-Bich/marcel-bich-claude-marketplace
 ```
+
+When using `/plugin` commands within a Claude session, restart Claude afterwards for changes to take effect.
+
+## Updating
+
+To receive plugin updates:
+
+1. Run `/plugin` in Claude Code
+2. Go to the **Marketplaces** tab
+3. Enable **"Enable auto-update"** for automatic updates, or select **"Update marketplace"** manually
+4. Go to the **Installed** tab and update individual plugins as needed
+5. Restart Claude Code after updating
 
 ## Available Plugins
 
@@ -31,22 +48,6 @@ Or within a Claude session:
 /plugin install signal@marcel-bich-claude-marketplace
 ```
 
-When using those `/plugin` commands within a Claude session, restart Claude afterwards for changes to take effect.
-
-## Updating
-
-To receive plugin updates:
-
-1. Run `/plugin` in Claude Code
-2. Go to the **Marketplaces** tab
-3. Enable **"Enable auto-update"** for automatic updates, or select **"Update marketplace"** manually
-4. Go to the **Installed** tab and update individual plugins as needed
-5. Restart Claude Code after updating
-
-## Available Plugins
-
-### signal
-
 **Features:**
 - Live status updates via desktop notifications
 - Sound alerts for task completion and attention requests
@@ -54,6 +55,33 @@ To receive plugin updates:
 - Smart filtering to prevent notification spam
 
 See [plugins/signal/README.md](plugins/signal/README.md) for full documentation.
+
+---
+
+### limit
+
+Live API usage display in Claude Code statusline - shows your utilization with colored progress bars and reset times.
+
+**Install:**
+```bash
+claude plugin install limit@marcel-bich-claude-marketplace
+```
+
+Or within a Claude session:
+```
+/plugin install limit@marcel-bich-claude-marketplace
+```
+
+**Features:**
+- Real API data from Anthropic (same as `/usage`)
+- Colored progress bars with signal colors
+- Multiple limits: 5-hour, 7-day, Opus, Sonnet, Extra Credits
+- Reset times for each limit
+- All features toggleable via environment variables
+
+See [plugins/limit/README.md](plugins/limit/README.md) for full documentation.
+
+---
 
 ## License
 

--- a/plugins/limit/.claude-plugin/plugin.json
+++ b/plugins/limit/.claude-plugin/plugin.json
@@ -1,0 +1,7 @@
+{
+  "name": "limit",
+  "version": "1.0.0",
+  "description": "Live API usage display in Claude Code statusline - shows utilization with colored progress bars and reset times. Supports 5-hour, 7-day, Opus, Sonnet, and Extra Credits limits.",
+  "keywords": ["usage", "statusline", "api", "quota", "limits", "utilization"],
+  "license": "MIT"
+}

--- a/plugins/limit/LICENSE
+++ b/plugins/limit/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/limit/README.md
+++ b/plugins/limit/README.md
@@ -1,0 +1,189 @@
+# limit
+
+Live API usage display in Claude Code statusline - shows your utilization with colored progress bars and reset times using real Anthropic API data.
+
+**Use case:** You want to see your actual API usage limits (the same data shown by `/usage`) directly in the statusline, updating with each Claude response.
+
+Unlike tools that estimate usage from local logs, this plugin fetches the real utilization data from Anthropic's API.
+
+## Features
+
+- **Real API Data** - Shows actual utilization from Anthropic's OAuth API (same as `/usage`)
+- **Colored Progress Bars** - Visual indicators with signal colors based on utilization
+- **Multiple Limits** - 5-hour, 7-day, Opus, Sonnet, and Extra Credits
+- **Reset Times** - Shows exact reset date and time for each limit
+- **Smart Display** - Only shows limits that are available/relevant
+- **Cross-Platform** - Works on Linux, macOS, and WSL2
+
+## Output Example
+
+```
+5h [==--------]  14% reset 2026-01-08 22:00 | 7d [----------]   3% reset 2026-01-09 20:00
+```
+
+With high utilization (colored in terminal):
+```
+5h [=========-]  85% reset 2026-01-08 22:00 | 7d [===-------]  35% reset 2026-01-09 20:00
+```
+
+## Color Coding
+
+| Utilization | Color  | Meaning |
+|-------------|--------|---------|
+| < 30%       | Gray   | Low usage |
+| 30-49%      | Green  | Normal |
+| 50-74%      | Yellow | Moderate |
+| 75-89%      | Orange | High |
+| >= 90%      | Red    | Critical |
+
+## Displayed Limits
+
+| Limit | Description | When Shown |
+|-------|-------------|------------|
+| 5h | 5-hour rolling window | Always |
+| 7d | 7-day rolling window (all models) | Always (if available) |
+| Opus | 7-day Opus-specific limit | Only if you have Opus usage |
+| Sonnet | 7-day Sonnet-specific limit | Only if utilization > 0 |
+| Extra | Extra usage credits | Only if enabled AND used > $0 |
+
+## Requirements
+
+- `jq` - JSON processor (install: `sudo apt install jq`)
+- `curl` - HTTP client
+- `date` - GNU date (Linux/WSL) or BSD date (macOS)
+- Valid Claude Code OAuth session (login via `claude` CLI)
+
+## Installation
+
+```bash
+claude plugin marketplace add Marcel-Bich/marcel-bich-claude-marketplace
+claude plugin install limit@marcel-bich-claude-marketplace
+```
+
+After installation, add the statusline configuration to `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/plugins/limit@marcel-bich-claude-marketplace/scripts/usage-statusline.sh"
+  }
+}
+```
+
+**Note:** Restart Claude Code after changing settings.json.
+
+## Configuration
+
+Configure via environment variables in `~/.claude/settings.json`:
+
+```json
+{
+  "env": {
+    "CLAUDE_LIMIT_SHOW_ERRORS": "false",
+    "CLAUDE_LIMIT_DEBUG": "false"
+  },
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/plugins/limit@marcel-bich-claude-marketplace/scripts/usage-statusline.sh"
+  }
+}
+```
+
+### Options
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CLAUDE_LIMIT_5H` | `true` | Show 5-hour limit |
+| `CLAUDE_LIMIT_7D` | `true` | Show 7-day limit |
+| `CLAUDE_LIMIT_OPUS` | `true` | Show Opus limit (if available) |
+| `CLAUDE_LIMIT_SONNET` | `true` | Show Sonnet limit (if available) |
+| `CLAUDE_LIMIT_EXTRA` | `true` | Show extra credits (if used) |
+| `CLAUDE_LIMIT_COLORS` | `true` | Enable colored output |
+| `CLAUDE_LIMIT_PROGRESS` | `true` | Show progress bars |
+| `CLAUDE_LIMIT_RESET` | `true` | Show reset times |
+| `CLAUDE_LIMIT_SHOW_ERRORS` | `false` | Show "limit: error" on failures |
+| `CLAUDE_LIMIT_DEBUG` | `false` | Show raw API response for debugging |
+
+### Example: Minimal Output
+
+To show only the 5-hour percentage without colors or progress bars:
+
+```json
+{
+  "env": {
+    "CLAUDE_LIMIT_7D": "false",
+    "CLAUDE_LIMIT_COLORS": "false",
+    "CLAUDE_LIMIT_PROGRESS": "false",
+    "CLAUDE_LIMIT_RESET": "false"
+  }
+}
+```
+
+Output: `5h  14%`
+
+## How It Works
+
+1. Reads your OAuth token from `~/.claude/.credentials.json`
+2. Fetches usage data from Anthropic's OAuth API
+3. Formats each limit with colored progress bar, percentage, and reset time
+4. Updates automatically with each Claude response (statusline refresh)
+
+## Troubleshooting
+
+### Nothing displayed
+
+- Verify you're logged in: `claude /login`
+- Check if credentials exist: `ls ~/.claude/.credentials.json`
+- Test manually: Run the script directly in your terminal
+- Enable error display: `CLAUDE_LIMIT_SHOW_ERRORS=true ./path/to/script.sh`
+
+### Debug mode
+
+To see the raw API response:
+```bash
+CLAUDE_LIMIT_DEBUG=true ~/.claude/plugins/limit@marcel-bich-claude-marketplace/scripts/usage-statusline.sh
+```
+
+### "OAuth token missing user:profile scope"
+
+Some accounts may see this error. Workaround:
+1. Run `claude /login` to re-authenticate
+2. If issue persists, see: https://github.com/anthropics/claude-code/issues/15243
+
+### Colors not showing
+
+- Ensure your terminal supports ANSI color codes
+- Some terminals may need specific configuration for 256-color support (orange)
+
+### macOS date parsing issues
+
+The script supports both GNU date (Linux) and BSD date (macOS). If you encounter issues on macOS, ensure you have a recent version of the system tools.
+
+## Security
+
+This plugin reads your OAuth token from the local credentials file to authenticate API requests. The token is:
+
+- Only used locally to fetch your own usage data
+- Never transmitted anywhere except to Anthropic's official API
+- Never displayed in the statusline output
+
+**Important:** Do not let Claude Code read or execute this script during a session, as the script output could end up in the conversation context. The statusline runs in a separate process that does not feed back into Claude's context.
+
+## Known Limitations
+
+1. **Unofficial API** - The `/api/oauth/usage` endpoint is not officially documented and may change
+2. **Token Expiry** - If your OAuth token expires, you'll need to re-login with `claude /login`
+3. **Rate Limits** - The script is called on each statusline refresh; Anthropic may rate-limit excessive calls
+
+## Disclaimer
+
+This software is provided "as is", without warranty of any kind. Use at your own risk.
+
+- The author is **not responsible** for any issues arising from use of this plugin
+- The API endpoint used is not officially documented and may change without notice
+- **You are solely responsible** for ensuring this plugin works with your setup
+
+## License
+
+MIT - See [LICENSE](LICENSE) file for full terms.

--- a/plugins/limit/scripts/usage-statusline.sh
+++ b/plugins/limit/scripts/usage-statusline.sh
@@ -1,0 +1,322 @@
+#!/bin/bash
+# usage-statusline.sh - Display live API usage in Claude Code statusline
+# Shows utilization with progress bars, colors, and reset times from Anthropic API
+
+set -euo pipefail
+
+# Configuration
+CREDENTIALS_FILE="${HOME}/.claude/.credentials.json"
+API_URL="https://api.anthropic.com/api/oauth/usage"
+TIMEOUT=5
+
+# Debug mode - shows raw API response
+DEBUG="${CLAUDE_LIMIT_DEBUG:-false}"
+
+# Feature toggles (all default to true)
+SHOW_5H="${CLAUDE_LIMIT_5H:-true}"
+SHOW_7D="${CLAUDE_LIMIT_7D:-true}"
+SHOW_OPUS="${CLAUDE_LIMIT_OPUS:-true}"
+SHOW_SONNET="${CLAUDE_LIMIT_SONNET:-true}"
+SHOW_EXTRA="${CLAUDE_LIMIT_EXTRA:-true}"
+SHOW_COLORS="${CLAUDE_LIMIT_COLORS:-true}"
+SHOW_PROGRESS="${CLAUDE_LIMIT_PROGRESS:-true}"
+SHOW_RESET="${CLAUDE_LIMIT_RESET:-true}"
+
+# ANSI color codes
+COLOR_RESET='\033[0m'
+COLOR_GRAY='\033[90m'
+COLOR_GREEN='\033[32m'
+COLOR_YELLOW='\033[33m'
+COLOR_ORANGE='\033[38;5;208m'
+COLOR_RED='\033[31m'
+
+# Progress bar characters
+BAR_FILLED='='
+BAR_EMPTY='-'
+BAR_WIDTH=10
+
+# Silent error exit for statusline
+error_exit() {
+    if [[ "${CLAUDE_LIMIT_SHOW_ERRORS:-false}" == "true" ]]; then
+        echo "limit: error"
+    fi
+    exit 0
+}
+
+# Check dependencies
+check_dependencies() {
+    command -v jq >/dev/null 2>&1 || error_exit
+    command -v curl >/dev/null 2>&1 || error_exit
+}
+
+# Read OAuth token from credentials file
+get_token() {
+    if [[ ! -f "$CREDENTIALS_FILE" ]]; then
+        error_exit
+    fi
+
+    local token
+    token=$(jq -r '.claudeAiOauth.accessToken // empty' "$CREDENTIALS_FILE" 2>/dev/null)
+
+    if [[ -z "$token" ]]; then
+        error_exit
+    fi
+
+    echo "$token"
+}
+
+# Fetch usage data from API
+fetch_usage() {
+    local token="$1"
+
+    local response
+    response=$(curl -s -f --max-time "$TIMEOUT" \
+        -X GET "$API_URL" \
+        -H "Authorization: Bearer $token" \
+        -H "Content-Type: application/json" \
+        -H "anthropic-beta: oauth-2025-04-20" \
+        -H "User-Agent: claude-code-limit-plugin/1.0.0" \
+        2>/dev/null) || error_exit
+
+    echo "$response"
+}
+
+# Get color based on utilization percentage
+# <30% gray, <50% green, <75% yellow, <90% orange, >=90% red
+get_color() {
+    local pct="$1"
+
+    # Return empty if colors disabled
+    if [[ "$SHOW_COLORS" != "true" ]]; then
+        echo ""
+        return
+    fi
+
+    if [[ -z "$pct" ]] || [[ "$pct" == "-" ]]; then
+        echo "$COLOR_GRAY"
+        return
+    fi
+
+    if [[ "$pct" -lt 30 ]]; then
+        echo "$COLOR_GRAY"
+    elif [[ "$pct" -lt 50 ]]; then
+        echo "$COLOR_GREEN"
+    elif [[ "$pct" -lt 75 ]]; then
+        echo "$COLOR_YELLOW"
+    elif [[ "$pct" -lt 90 ]]; then
+        echo "$COLOR_ORANGE"
+    else
+        echo "$COLOR_RED"
+    fi
+}
+
+# Generate ASCII progress bar
+# Usage: progress_bar <percentage> <width>
+progress_bar() {
+    local pct="$1"
+    local width="${2:-$BAR_WIDTH}"
+
+    if [[ -z "$pct" ]] || [[ "$pct" == "-" ]]; then
+        pct=0
+    fi
+
+    # Clamp percentage to 0-100
+    if [[ "$pct" -lt 0 ]]; then
+        pct=0
+    elif [[ "$pct" -gt 100 ]]; then
+        pct=100
+    fi
+
+    local filled=$((pct * width / 100))
+    local empty=$((width - filled))
+
+    local bar=""
+    for ((i=0; i<filled; i++)); do
+        bar+="$BAR_FILLED"
+    done
+    for ((i=0; i<empty; i++)); do
+        bar+="$BAR_EMPTY"
+    done
+
+    echo "[$bar]"
+}
+
+# Format reset time as "yyyy-mm-dd hh:mm"
+format_reset_datetime() {
+    local reset_at="$1"
+
+    if [[ -z "$reset_at" ]] || [[ "$reset_at" == "null" ]]; then
+        echo "-"
+        return
+    fi
+
+    local formatted
+    if date --version >/dev/null 2>&1; then
+        # GNU date (Linux/WSL)
+        formatted=$(date -d "$reset_at" "+%Y-%m-%d %H:%M" 2>/dev/null) || formatted="-"
+    else
+        # BSD date (macOS)
+        formatted=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${reset_at%%.*}" "+%Y-%m-%d %H:%M" 2>/dev/null) || formatted="-"
+    fi
+
+    echo "$formatted"
+}
+
+# Format a single limit line with color, progress bar, percentage, and reset time
+# Usage: format_limit_line <label> <percentage> <reset_at>
+format_limit_line() {
+    local label="$1"
+    local pct="$2"
+    local reset_at="$3"
+
+    local color=""
+    local color_reset=""
+    if [[ "$SHOW_COLORS" == "true" ]]; then
+        color=$(get_color "$pct")
+        color_reset="$COLOR_RESET"
+    fi
+
+    local bar=""
+    if [[ "$SHOW_PROGRESS" == "true" ]]; then
+        bar=" $(progress_bar "$pct")"
+    fi
+
+    local reset_str=""
+    if [[ "$SHOW_RESET" == "true" ]]; then
+        reset_str=" reset $(format_reset_datetime "$reset_at")"
+    fi
+
+    # Output varies based on toggles, e.g.: "Label [====------] 14% reset 2026-01-08 22:00"
+    printf "${color}%s%s %3s%%${reset_str}${color_reset}" "$label" "$bar" "$pct"
+}
+
+# Parse integer from value (handles int, float, null, empty)
+parse_int() {
+    local val="$1"
+
+    if [[ -z "$val" ]] || [[ "$val" == "null" ]]; then
+        echo ""
+        return
+    fi
+
+    # Try printf for floats, fallback to raw value
+    local result
+    result=$(printf "%.0f" "$val" 2>/dev/null || echo "$val")
+    result="${result%%.*}"
+
+    echo "$result"
+}
+
+# Main output formatting
+format_output() {
+    local response="$1"
+    local output=""
+
+    # Extract all values using jq
+    local five_hour_util five_hour_reset
+    local seven_day_util seven_day_reset
+    local opus_util opus_reset
+    local sonnet_util sonnet_reset
+    local extra_enabled extra_limit extra_used
+
+    five_hour_util=$(echo "$response" | jq -r '.five_hour.utilization // empty' 2>/dev/null)
+    five_hour_reset=$(echo "$response" | jq -r '.five_hour.resets_at // empty' 2>/dev/null)
+    seven_day_util=$(echo "$response" | jq -r '.seven_day.utilization // empty' 2>/dev/null)
+    seven_day_reset=$(echo "$response" | jq -r '.seven_day.resets_at // empty' 2>/dev/null)
+    opus_util=$(echo "$response" | jq -r '.seven_day_opus.utilization // empty' 2>/dev/null)
+    opus_reset=$(echo "$response" | jq -r '.seven_day_opus.resets_at // empty' 2>/dev/null)
+    sonnet_util=$(echo "$response" | jq -r '.seven_day_sonnet.utilization // empty' 2>/dev/null)
+    sonnet_reset=$(echo "$response" | jq -r '.seven_day_sonnet.resets_at // empty' 2>/dev/null)
+    extra_enabled=$(echo "$response" | jq -r '.extra_usage.is_enabled // empty' 2>/dev/null)
+    extra_limit=$(echo "$response" | jq -r '.extra_usage.monthly_limit // empty' 2>/dev/null)
+    extra_used=$(echo "$response" | jq -r '.extra_usage.used_credits // empty' 2>/dev/null)
+
+    # Required: 5-hour limit
+    if [[ -z "$five_hour_util" ]] || [[ -z "$five_hour_reset" ]]; then
+        error_exit
+    fi
+
+    local five_pct seven_pct opus_pct sonnet_pct
+    five_pct=$(parse_int "$five_hour_util")
+    seven_pct=$(parse_int "$seven_day_util")
+    opus_pct=$(parse_int "$opus_util")
+    sonnet_pct=$(parse_int "$sonnet_util")
+
+    # Build output lines
+    local lines=()
+
+    # 5-hour limit (if enabled)
+    if [[ "$SHOW_5H" == "true" ]]; then
+        lines+=("$(format_limit_line "5h" "$five_pct" "$five_hour_reset")")
+    fi
+
+    # 7-day limit (if enabled and available)
+    if [[ "$SHOW_7D" == "true" ]] && [[ -n "$seven_pct" ]]; then
+        lines+=("$(format_limit_line "7d" "$seven_pct" "$seven_day_reset")")
+    fi
+
+    # Opus limit (if enabled and has data)
+    if [[ "$SHOW_OPUS" == "true" ]] && [[ -n "$opus_pct" ]]; then
+        lines+=("$(format_limit_line "Opus" "$opus_pct" "$opus_reset")")
+    fi
+
+    # Sonnet limit (if enabled and has utilization > 0 or reset time)
+    if [[ "$SHOW_SONNET" == "true" ]] && [[ -n "$sonnet_pct" ]] && { [[ "$sonnet_pct" -gt 0 ]] || [[ -n "$sonnet_reset" && "$sonnet_reset" != "null" ]]; }; then
+        lines+=("$(format_limit_line "Sonnet" "$sonnet_pct" "$sonnet_reset")")
+    fi
+
+    # Extra usage (if enabled AND used_credits > 0)
+    if [[ "$SHOW_EXTRA" == "true" ]] && [[ "$extra_enabled" == "true" ]] && [[ -n "$extra_used" ]] && [[ "$extra_used" != "0" ]] && [[ "$extra_used" != "null" ]]; then
+        local extra_pct=0
+        if [[ -n "$extra_limit" ]] && [[ "$extra_limit" -gt 0 ]]; then
+            extra_pct=$((extra_used * 100 / extra_limit))
+        fi
+        local extra_color=""
+        local extra_color_reset=""
+        if [[ "$SHOW_COLORS" == "true" ]]; then
+            extra_color=$(get_color "$extra_pct")
+            extra_color_reset="$COLOR_RESET"
+        fi
+        local extra_bar=""
+        if [[ "$SHOW_PROGRESS" == "true" ]]; then
+            extra_bar=" $(progress_bar "$extra_pct")"
+        fi
+        printf -v extra_line "${extra_color}Extra%s \$%s/\$%s${extra_color_reset}" "$extra_bar" "$extra_used" "$extra_limit"
+        lines+=("$extra_line")
+    fi
+
+    # Join lines with " | " separator
+    local first=true
+    for line in "${lines[@]}"; do
+        if [[ "$first" == "true" ]]; then
+            output="$line"
+            first=false
+        else
+            output="$output | $line"
+        fi
+    done
+
+    echo -e "$output"
+}
+
+# Main execution
+main() {
+    check_dependencies
+
+    local token
+    token=$(get_token)
+
+    local response
+    response=$(fetch_usage "$token")
+
+    # Debug mode - show raw response structure
+    if [[ "$DEBUG" == "true" ]]; then
+        echo "DEBUG: Raw API response:"
+        echo "$response" | jq '.' 2>/dev/null || echo "$response"
+        echo "---"
+    fi
+
+    format_output "$response"
+}
+
+main

--- a/plugins/signal/README.md
+++ b/plugins/signal/README.md
@@ -19,13 +19,13 @@ Works great with `claude --dangerously-skip-permissions` for autonomous workflow
 
 ### Linux
 - Desktop notifications (GNOME, KDE, etc.)
-- `jq` - JSON processor
+- `jq` - JSON processor (install: `sudo apt install jq`)
 - `gdbus` or `notify-send` - For desktop notifications
 - `paplay` and `pactl` - For sound alerts (optional, part of PulseAudio)
 - `bc` - For volume calculations (optional)
 
 ### WSL2 (Windows 10/11)
-- `jq` - JSON processor
+- `jq` - JSON processor (install: `sudo apt install jq`)
 - `powershell.exe` - For Windows toast notifications and sounds (available by default in WSL)
 - Optional: [BurntToast](https://github.com/Windos/BurntToast) PowerShell module for better notifications
 


### PR DESCRIPTION
## Summary

- Add new `limit` plugin showing live API usage in statusline
- Real API data from Anthropic OAuth endpoint (same as `/usage`)
- Colored progress bars with signal colors (gray/green/yellow/orange/red)
- Multiple limits: 5-hour, 7-day, Opus, Sonnet, Extra Credits
- All features toggleable via environment variables
- Cross-platform support: Linux, macOS, WSL2

## Changes

- `plugins/limit/` - New plugin with script, README, LICENSE, plugin.json
- `README.md` - Added jq requirement and limit plugin documentation
- `plugins/signal/README.md` - Added jq installation instructions

## Test plan

- [x] Script executes without errors
- [x] Progress bars display correctly
- [x] Colors work in terminal
- [x] Reset times formatted as yyyy-mm-dd hh:mm
- [x] Feature toggles work (CLAUDE_LIMIT_* env vars)