### PR TITLE
v1.2.6: signal sound fallback (pw-play, ffplay) for Linux without paplay

### DIFF
--- a/plugins/signal/.claude-plugin/plugin.json
+++ b/plugins/signal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "signal",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Desktop notifications showing what Claude Code is working on - stay informed even when the terminal is not in focus. Optional sound alerts and AI summaries",
   "keywords": [
     "notifications",

--- a/plugins/signal/README.md
+++ b/plugins/signal/README.md
@@ -19,6 +19,16 @@ Desktop notifications showing what Claude Code is working on - stay informed eve
 
 - `jq` - JSON processor (install: `sudo apt install jq`)
 
+### Optional (sound alerts on Linux)
+
+Sound is optional. On Linux the plugin tries the first available player in this order:
+
+- `paplay` (PulseAudio, `pulseaudio-utils`) - honours the configured volume
+- `pw-play` (PipeWire, `pipewire-bin` on Debian/Ubuntu) - honours the configured volume
+- `ffplay` (ffmpeg) - plays at full volume (no per-play volume control)
+
+If none is installed, notifications still work; only the sound is skipped. On WSL2 the Windows system sound is used instead.
+
 ## Kitty Tab Indicator
 
 Marks the kitty terminal tab title with a prefix during active Claude sessions so you can tell at a glance which tabs are running Claude.
@@ -61,6 +71,6 @@ MIT - See [LICENSE](LICENSE) for full terms.
 <details>
 <summary>Keywords / Tags</summary>
 
-Claude Code, Claude Code Plugin, Claude Code Extension, Claude Code Notifications, Claude Code Desktop Notifications, Claude Code Terminal Notifications, Claude Code Alerts, Claude Code Sound, Claude Code Audio, Claude Code Toast, Claude Code Status, Claude Code Progress, Claude Code Monitoring, Claude Code Background, Claude Code Autonomous, Claude Code Dangerously Skip Permissions, Anthropic CLI, Anthropic Plugin, Anthropic Extension, Anthropic Claude, Anthropic AI, AI Agent Notifications, AI Agent Alerts, AI Agent Status, AI Agent Monitoring, AI Code Assistant, AI Coding, AI Programming, AI Development, Desktop Notifications, Terminal Notifications, System Notifications, Toast Notifications, Push Notifications, Sound Alerts, Audio Alerts, Notification Sound, Complete Sound, Attention Sound, WSL, WSL2, WSL Notifications, Windows Subsystem Linux, Windows 10, Windows 11, Windows Notifications, Linux Notifications, GNOME Notifications, KDE Notifications, Ubuntu Notifications, Debian Notifications, notify-send, gdbus, BurntToast, PowerShell Notifications, PulseAudio, paplay, pactl, Cross Platform, Background Tasks, Autonomous Coding, Haiku Summary, AI Summary, Task Completion, Tool Waiting, Permission Prompt, Input Required, Claude Code Hooks, Stop Hook, PreToolUse Hook, Notification Hook, Marcel Bich, marcel-bich-claude-marketplace, signal plugin, notification plugin
+Claude Code, Claude Code Plugin, Claude Code Extension, Claude Code Notifications, Claude Code Desktop Notifications, Claude Code Terminal Notifications, Claude Code Alerts, Claude Code Sound, Claude Code Audio, Claude Code Toast, Claude Code Status, Claude Code Progress, Claude Code Monitoring, Claude Code Background, Claude Code Autonomous, Claude Code Dangerously Skip Permissions, Anthropic CLI, Anthropic Plugin, Anthropic Extension, Anthropic Claude, Anthropic AI, AI Agent Notifications, AI Agent Alerts, AI Agent Status, AI Agent Monitoring, AI Code Assistant, AI Coding, AI Programming, AI Development, Desktop Notifications, Terminal Notifications, System Notifications, Toast Notifications, Push Notifications, Sound Alerts, Audio Alerts, Notification Sound, Complete Sound, Attention Sound, WSL, WSL2, WSL Notifications, Windows Subsystem Linux, Windows 10, Windows 11, Windows Notifications, Linux Notifications, GNOME Notifications, KDE Notifications, Ubuntu Notifications, Debian Notifications, notify-send, gdbus, BurntToast, PowerShell Notifications, PulseAudio, paplay, pactl, PipeWire, pw-play, ffplay, ffmpeg, Cross Platform, Background Tasks, Autonomous Coding, Haiku Summary, AI Summary, Task Completion, Tool Waiting, Permission Prompt, Input Required, Claude Code Hooks, Stop Hook, PreToolUse Hook, Notification Hook, Marcel Bich, marcel-bich-claude-marketplace, signal plugin, notification plugin
 
 </details>

--- a/plugins/signal/plugin.yaml
+++ b/plugins/signal/plugin.yaml
@@ -1,6 +1,6 @@
 name: signal
 description: Desktop notifications showing what Claude Code is working on - stay informed even when the terminal is not in focus. Optional sound alerts and AI summaries
-version: 1.2.5
+version: 1.2.6
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/signal/scripts/hook-notify.sh
+++ b/plugins/signal/scripts/hook-notify.sh
@@ -138,10 +138,22 @@ if is_wsl; then
     # WSL: Use Windows system sound with volume
     windows_sound "$SOUND_TYPE" "$SOUND_VOLUME"
 elif command -v paplay &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
-    # Linux: Original paplay code
+    # Linux (PulseAudio): paplay uses pactl for current sink volume + paplay --volume
     CURRENT_VOL=$(pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null | grep -oP '\d+(?=%)' | head -1)
     PLAY_VOL=$(echo "${CURRENT_VOL:-50} * $SOUND_VOLUME * 655.36" | bc 2>/dev/null | cut -d. -f1)
     [ -n "$PLAY_VOL" ] && paplay --volume="$PLAY_VOL" "$SOUND_FILE" 2>/dev/null &
+elif command -v pw-play &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
+    # Linux (PipeWire): fallback when paplay is not installed.
+    # pw-play --volume takes a float 0.0-1.0; use SOUND_VOLUME directly if in range, else play without it.
+    if [ "$(echo "$SOUND_VOLUME <= 1" | bc 2>/dev/null)" = "1" ]; then
+        pw-play --volume="$SOUND_VOLUME" "$SOUND_FILE" 2>/dev/null &
+    else
+        pw-play "$SOUND_FILE" 2>/dev/null &
+    fi
+elif command -v ffplay &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
+    # Linux (ffmpeg): last-resort fallback. ffplay has no simple linear volume flag,
+    # so sound plays at full volume - sound without exact volume beats no sound at all.
+    ffplay -nodisp -autoexit -loglevel quiet "$SOUND_FILE" 2>/dev/null &
 fi
 
 exit 0

--- a/plugins/signal/scripts/stop-notify.sh
+++ b/plugins/signal/scripts/stop-notify.sh
@@ -134,10 +134,22 @@ if is_wsl; then
     # WSL: Use Windows system sound with volume
     windows_sound "complete" "$SOUND_VOLUME"
 elif command -v paplay &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
-    # Linux: Original paplay code
+    # Linux (PulseAudio): paplay uses pactl for current sink volume + paplay --volume
     CURRENT_VOL=$(pactl get-sink-volume @DEFAULT_SINK@ 2>/dev/null | grep -oP '\d+(?=%)' | head -1)
     PLAY_VOL=$(echo "${CURRENT_VOL:-50} * $SOUND_VOLUME * 655.36" | bc 2>/dev/null | cut -d. -f1)
     [ -n "$PLAY_VOL" ] && paplay --volume="$PLAY_VOL" /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
+elif command -v pw-play &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
+    # Linux (PipeWire): fallback when paplay is not installed.
+    # pw-play --volume takes a float 0.0-1.0; use SOUND_VOLUME directly if in range, else play without it.
+    if [ "$(echo "$SOUND_VOLUME <= 1" | bc 2>/dev/null)" = "1" ]; then
+        pw-play --volume="$SOUND_VOLUME" /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
+    else
+        pw-play /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
+    fi
+elif command -v ffplay &> /dev/null && [ "$(echo "$SOUND_VOLUME > 0" | bc 2>/dev/null)" = "1" ]; then
+    # Linux (ffmpeg): last-resort fallback. ffplay has no simple linear volume flag,
+    # so sound plays at full volume - sound without exact volume beats no sound at all.
+    ffplay -nodisp -autoexit -loglevel quiet /usr/share/sounds/freedesktop/stereo/complete.oga 2>/dev/null &
 fi
 
 exit 0


### PR DESCRIPTION
## Summary
Fixes #4. The signal plugin only played sound via `paplay` on native Linux, with no fallback. On PipeWire systems (e.g. Ubuntu 24.04) where `pulseaudio-utils`/`paplay` is not installed, no sound played at all (silent, no error).

## Change
Adds a strict fallback chain in both `hook-notify.sh` and `stop-notify.sh`:

`paplay` (PulseAudio) -> `pw-play` (PipeWire) -> `ffplay` (ffmpeg)

- Exactly one player runs (elif cascade); WSL behaviour unchanged.
- Same `SOUND_VOLUME > 0` guard as before on all branches.
- `pw-play` uses the configured volume (float 0.0-1.0; values >1 fall back to full volume).
- `ffplay` is the last resort and plays at full volume (no per-play volume control).

## Files
- `plugins/signal/scripts/hook-notify.sh`, `stop-notify.sh` - fallback chain
- `plugins/signal/.claude-plugin/plugin.json`, `plugin.yaml` - version 1.2.5 -> 1.2.6
- `plugins/signal/README.md` - documents the player order and packages (`pipewire-bin` on Debian/Ubuntu)

## Validation
- `bash -n` passes on both scripts.
- Branch logic dry-tested for all player-availability combinations (each case fires exactly one branch; none installed -> silent, no crash).
- Package name verified via `dpkg -S`: `pw-play` is in `pipewire-bin` on Debian/Ubuntu (there is no `pipewire-utils` package there).

Note: real audio playback on a PipeWire-only system (no paplay) was not physically tested; verification covered syntax and branch selection.