### PR TITLE
credo v0.18.0: enforce autonomy keep-alive via registered hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ credo is the mentor - a self-contained process framework that governs how a whol
 - **Budget and limit awareness** - credo reads the 5-hour and weekly usage caps, sizes tasks to fit, and pauses or hands off before a wall is hit.
 - **Verify and wiring checks** - "done" means the code is actually wired in and observably works, not just "the test passed".
 - **Safety that travels** - filesystem protection and no-autonomous-installs rules are re-injected into every subagent, so delegation cannot dilute them.
-- **Autonomy handling** - approved GO items are worked unattended with best-effort self-scheduled wake-ups, budget caps, and ntfy notifications per task and question.
+- **Autonomy handling** - approved GO items are worked unattended with hook-enforced self-scheduled wake-ups (a registered Stop hook blocks a stop without a scheduled ScheduleWakeup), budget caps, and ntfy notifications per task and question.
 - **Subagent priming** - every subagent starts with the load-bearing security, quality, and honesty rules already in context.
 - **WSL environment awareness** - reach Windows-side services and launchers from WSL, self-detecting.
 - **Opt-in versioning** - keep `.credo/` local by default, or version items and process in the repo with a single flag.

--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -35,7 +35,7 @@ The mode is per session and set with a command. It is stored on disk keyed by th
 
 - **active** (`/credo:session-active`) - intensive live collaboration with the user at the keyboard. Progress is logged via the limit thresholds and compact-plus, open GO items are picked up alongside, clarifications happen during subagent waits. No keep-alive.
 - **passive** (`/credo:session-passive`) - the agent carries most of the work while the user is reachable only for clarifications. Every item is pushed toward a full GO; less is more, so only genuinely ambiguous items go back to the user. No keep-alive.
-- **autonomous** (`/credo:session-autonomous`) - approved GO items are worked unattended. Keep-alive is best-effort: the model schedules its own wake-ups via ScheduleWakeup (there is no registered Stop hook that forces it). Budget caps are enforced, ntfy fires per task and per question, and progress is secured via compact-plus.
+- **autonomous** (`/credo:session-autonomous`) - approved GO items are worked unattended. Keep-alive is hook-enforced: a registered Stop hook blocks a stop that has no scheduled ScheduleWakeup and instructs the model to set one (loop-safe, and inert outside autonomy); a registered UserPromptSubmit hook turns autonomy off on any real user message. Budget caps are enforced, ntfy fires per task and per question, and progress is secured via compact-plus.
 
 Each command sets the mode and loads its skill. The three session skills share one canonical common core (defined in the session-active skill) and layer their mode-specific rules on top.
 

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -66,7 +66,7 @@ credo runs a session in one of three exclusive modes. The active mode is re-inje
 
 - `/credo:session-active` - intensive live collaboration, you at the keyboard, no keep-alive.
 - `/credo:session-passive` - the agent carries most of the work; you stay reachable for clarifications only, no keep-alive.
-- `/credo:session-autonomous` - approved GO items worked unattended, keep-alive intent on (best-effort, the agent schedules its own wake-ups), budget caps enforced, ntfy per task and question, progress secured via compact-plus.
+- `/credo:session-autonomous` - approved GO items worked unattended, keep-alive on (hook-enforced: a registered Stop hook blocks a stop without a scheduled wake-up), budget caps enforced, ntfy per task and question, progress secured via compact-plus.
 
 Pick the mode that matches how present you are. Switch any time by running the matching command.
 

--- a/plugins/credo/commands/session-autonomous.md
+++ b/plugins/credo/commands/session-autonomous.md
@@ -1,5 +1,5 @@
 ---
-description: credo - Set the session mode to autonomous (work approved GO items unattended, keep-alive intent ON - best-effort)
+description: credo - Set the session mode to autonomous (work approved GO items unattended, hook-enforced keep-alive ON)
 arguments: none
 allowed-tools:
   - Bash(${CLAUDE_PLUGIN_ROOT}/hooks/session-mode-set.sh:*)
@@ -14,10 +14,11 @@ Use this ONLY when full autonomy plus AFK has been explicitly granted.
 
 1. Run: `${CLAUDE_PLUGIN_ROOT}/hooks/session-mode-set.sh autonomous`
    This writes the per-session state (keyed by the current session_id) and turns
-   the keep-alive intent ON (sets `credo-autonomy-active`, lifts the
-   `credo-autonomy-paused` opt-out). Keep-alive is best-effort and
-   instruction-driven: the model schedules its own wake-ups via ScheduleWakeup;
-   there is no registered Stop hook that enforces it (see the loaded skill).
+   keep-alive ON (sets `credo-autonomy-active`, lifts the
+   `credo-autonomy-paused` opt-out). Keep-alive is hook-enforced: a registered
+   Stop hook blocks a stop that has no scheduled ScheduleWakeup and instructs the
+   model to set one, and a registered UserPromptSubmit hook turns autonomy off on
+   any real user message (see the loaded skill).
 2. Load the skill `session-autonomous` and follow its rules strictly (budget
    caps, ntfy per task and question, ScheduleWakeup plus wake marker,
    compact-plus).

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -20,11 +20,13 @@ Design principles:
 
 - **commands/** - six slash commands: `psalm`, `setup`, `session-init`, and the three mode setters `session-active`, `session-passive`, `session-autonomous`.
 - **skills/** - fourteen auto-discovered skills (see section 6). Each auto-triggers when it applies, including inside subagents.
-- **hooks/** - exactly two hooks are registered in `hooks/hooks.json`:
+- **hooks/** - four hooks are registered in `hooks/hooks.json`:
   - `session-mode-inject.sh` (`UserPromptSubmit`) - re-injects the active session mode on every prompt and names the skill to load.
+  - `credo-autonomy-clear.sh` (`UserPromptSubmit`) - a real user message turns autonomy off (drops the flag, sets the paused opt-out).
   - `credo-subagent-inject.sh` (`SubagentStart`) - primes every subagent with the load-bearing rules.
+  - `credo-autonomy-keepalive.sh` (`Stop`) - in autonomous mode, blocks a stop that has no scheduled self-wake and instructs the agent to call ScheduleWakeup.
 
-  The autonomy scripts (`credo-autonomy-on.sh`, `credo-autonomy-off.sh`, `credo-autonomy-clear.sh`, `credo-autonomy-keepalive.sh`, `credo-autonomy-wake-mark.sh`) and `session-mode-set.sh` are plain helper scripts invoked by the session commands and skills - they are NOT registered as hooks. In particular `credo-autonomy-keepalive.sh` is written as a `Stop` hook and `credo-autonomy-clear.sh` as a `UserPromptSubmit` companion, but neither is wired into `hooks.json`. So there is no runtime Stop-hook enforcement of keep-alive today; autonomous keep-alive is best-effort and instruction-driven (see section 4).
+  The remaining autonomy scripts (`credo-autonomy-on.sh`, `credo-autonomy-off.sh`, `credo-autonomy-wake-mark.sh`) and `session-mode-set.sh` are plain helper scripts invoked by the session commands and skills - they are NOT hooks. Because the `Stop` and second `UserPromptSubmit` hooks are now wired into `hooks.json`, autonomous keep-alive is hook-enforced at runtime (loop-safe, and inert outside autonomy - see section 4).
 - **scripts/** - `check-setup.sh`, `credo-init.sh`, `credo-id-next.sh`, `credo-config.sh`, `credo-budget-read.sh`, `credo-item-move.sh`.
 - **templates/** - `config.default.yaml` (builtin config defaults) and `item.template.md` (the work-item template).
 
@@ -96,11 +98,11 @@ Set the mode with a command; it also loads the matching skill.
 
 - `/credo:session-active` - intensive live collaboration, user at the keyboard, no keep-alive.
 - `/credo:session-passive` - agent carries most work, user reachable for clarifications only, no keep-alive.
-- `/credo:session-autonomous` - approved GO items worked unattended, best-effort keep-alive (the model schedules its own `ScheduleWakeup` wake-ups; there is no Stop hook that forces it), budget caps enforced, ntfy per task and question, progress secured via compact-plus.
+- `/credo:session-autonomous` - approved GO items worked unattended, hook-enforced keep-alive (a registered `Stop` hook blocks a stop with no scheduled `ScheduleWakeup` and instructs the model to set one), budget caps enforced, ntfy per task and question, progress secured via compact-plus.
 
 The active skill defines the common core shared by all three; passive and autonomous layer their differences on top. On every prompt the inject line reminds you of the current mode, so it cannot be silently forgotten.
 
-Honest note on keep-alive: autonomous mode sets the `credo-autonomy-active` flag and instructs the model to keep itself awake by scheduling its own wake-ups, but nothing enforces this at runtime - the `Stop`/`UserPromptSubmit` autonomy hooks are shipped as helper scripts and are not registered (section 2.1). Keep-alive is therefore best-effort: it works as long as the model follows the instruction and calls `ScheduleWakeup` itself.
+Honest note on keep-alive: autonomous mode sets the `credo-autonomy-active` flag, and a registered `Stop` hook (`credo-autonomy-keepalive.sh`) enforces the keep-alive discipline - if you try to end the turn without a marked self-wake, it blocks the stop and instructs you to call `ScheduleWakeup` now; the registered `UserPromptSubmit` hook (`credo-autonomy-clear.sh`) turns autonomy off on any real user message (section 2.1). This is enforcement of the nudge, not a guarantee of infinite wakefulness: the hook forces the block plus instruction, but staying awake still depends on the model then calling `ScheduleWakeup`. It is loop-safe (at most one forced continuation per stop attempt, via the `stop_hook_active` guard) and completely inert outside autonomous mode.
 
 ## 5. The item workflow: how-to
 

--- a/plugins/credo/hooks/credo-autonomy-clear.sh
+++ b/plugins/credo/hooks/credo-autonomy-clear.sh
@@ -14,9 +14,9 @@
 #
 # Failure-safe: any error -> exit 0 (never block a prompt).
 #
-# NOTE: this is a coupling helper built in Phase 2. It is not registered in the
-# plugin hooks manifest yet; the live UserPromptSubmit registration is part of
-# the later switchover phase.
+# NOTE: this is registered in the plugin hooks manifest (hooks/hooks.json) as a
+# UserPromptSubmit hook, together with credo-autonomy-keepalive.sh on Stop. A
+# real user message thus turns autonomy off at runtime.
 set -u
 
 FLAG="$HOME/.claude/credo-autonomy-active"

--- a/plugins/credo/hooks/credo-autonomy-keepalive.sh
+++ b/plugins/credo/hooks/credo-autonomy-keepalive.sh
@@ -9,9 +9,9 @@
 #
 # Failure-safe: any error -> exit 0 (never hang a stop).
 #
-# NOTE: this is a coupling helper built in Phase 2. It is not registered in the
-# plugin hooks manifest yet; the live Stop registration is part of the later
-# switchover phase.
+# NOTE: this is registered in the plugin hooks manifest (hooks/hooks.json) as a
+# Stop hook, together with credo-autonomy-clear.sh on UserPromptSubmit. It
+# actively enforces the keep-alive discipline at runtime.
 set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/plugins/credo/hooks/hooks.json
+++ b/plugins/credo/hooks/hooks.json
@@ -7,6 +7,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/session-mode-inject.sh",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-autonomy-clear.sh",
+            "timeout": 10
           }
         ]
       }
@@ -17,6 +22,17 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-subagent-inject.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-autonomy-keepalive.sh",
             "timeout": 10
           }
         ]

--- a/plugins/credo/hooks/session-mode-inject.sh
+++ b/plugins/credo/hooks/session-mode-inject.sh
@@ -51,7 +51,7 @@ case "$mode" in
         rules="passive: handle most work alongside, actively push every item to a 100 percent GO, less is more (only ambiguous items via the Ask tool), no keep-alive. Load skill session-passive."
         ;;
     autonomous)
-        rules="autonomous: work approved GO items only, best-effort keep-alive (you schedule your own ScheduleWakeup plus wake marker; not hook-enforced), budget caps enforced, ntfy per task and question, secure progress via compact-plus. Load skill session-autonomous."
+        rules="autonomous: work approved GO items only, hook-enforced keep-alive (a Stop hook blocks a stop with no scheduled wake; schedule your own ScheduleWakeup plus wake marker), budget caps enforced, ntfy per task and question, secure progress via compact-plus. Load skill session-autonomous."
         ;;
     *)
         # Unknown value -> do not invent a rule set, stay silent.

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.17.0
+version: 0.18.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 
@@ -24,5 +24,5 @@ commands:
     description: Set the session mode to passive (user available for clarifications only, no keep-alive)
     source: commands/session-passive.md
   session-autonomous:
-    description: Set the session mode to autonomous (work approved GO items unattended, keep-alive intent on - best-effort)
+    description: Set the session mode to autonomous (work approved GO items unattended, hook-enforced keep-alive on)
     source: commands/session-autonomous.md

--- a/plugins/credo/skills/session-autonomous/SKILL.md
+++ b/plugins/credo/skills/session-autonomous/SKILL.md
@@ -2,7 +2,7 @@
 name: session-autonomous
 description: >
   The credo behavior for a session running in AUTONOMOUS mode - work approved GO items
-  unattended while the user is away, best-effort self-scheduled keep-alive, budget caps always on. Load this when
+  unattended while the user is away, hook-enforced self-scheduled keep-alive, budget caps always on. Load this when
   the session-mode inject line says "Load skill session-autonomous", right after the
   /credo:session-autonomous command, or whenever you are working autonomously and unattended.
   Shares the canonical common core defined in the credo session-active skill, then adds the
@@ -62,23 +62,33 @@ commit-identity gate before every commit. Before starting an autonomous run, the
 first confirms with the user whether the default caps fit or need a temporary override, and
 until when (per the budget skill). Never exceed a cap to finish "just one more thing".
 
-### Keep-alive (best-effort, only while credo-autonomy-active is set)
+### Keep-alive (hook-enforced, only while credo-autonomy-active is set)
 
 Keep the session awake so an unattended run does not fall asleep while there is open work
-and budget. Keep-alive is best-effort and instruction-driven: YOU schedule your own
-wake-ups. There is no registered Stop hook that forces the turn to continue, so upholding
-the discipline below is what actually keeps an unattended run alive.
+and budget. This discipline is now hook-enforced. A registered `Stop` hook
+(`credo-autonomy-keepalive.sh`, wired in `hooks/hooks.json`) fires when you try to end the
+turn: if autonomy is active and no self-wake is marked, it blocks the stop and instructs you
+to call ScheduleWakeup now (and mark it). Paired with the registered `UserPromptSubmit` hook
+(`credo-autonomy-clear.sh`), any real user message turns autonomy off. The enforcement is a
+nudge, not a guarantee of infinite wakefulness: the hook forces the block plus instruction,
+but actually staying awake still relies on you then calling ScheduleWakeup. It is loop-safe -
+the hook forces AT MOST ONE continuation per stop attempt (via the `stop_hook_active` guard)
+and lets the stop through once a future wake is marked, so it can NOT spin forever. Outside
+autonomous mode (no flag set) the hook is completely inert - a plain no-op stop.
 
 - ScheduleWakeup is the PRIMARY self-wake mechanism. Its single delay is clamped to
   [60, 3600] seconds, so for a longer pause CHAIN several wake-ups rather than one long one.
-- Record each planned wake with `credo-autonomy-wake-mark.sh` so your own tracking stays
-  consistent. It is a plain helper script, not a registered hook, so it does not enforce
-  anything by itself - it just keeps a record of the next wake.
+- Record each planned wake with `credo-autonomy-wake-mark.sh` (same delaySeconds as the
+  ScheduleWakeup call). This is what the Stop hook checks to let the turn stop, so marking the
+  wake is what satisfies the enforcement.
 - On each wake, re-check the flag. If autonomy has been turned off (the user returned, or
   the run ended), do not keep building - end quietly.
 - Never end a turn without a scheduled wake-up while the flag is set and there is open work
-  plus budget. This is the standing keep-alive duty; because nothing enforces it for you,
-  you must uphold it yourself.
+  plus budget. The Stop hook enforces this nudge, but uphold the duty yourself rather than
+  relying on the block.
+- When the run is truly finished, on a showstopper, or at the weekly hard limit, end the mode
+  deliberately with `credo-autonomy-off.sh` - it clears the flag and sets the paused opt-out
+  so the Stop hook stays inert and you may stop.
 
 Wake-up offsets after a limit reset (default 5 minutes, fallback 1) come from the budget
 skill's `wakeup.*` config - use them when you pause for a limit to reset.


### PR DESCRIPTION
## Summary

Wires credo's autonomous-mode keep-alive hooks into the plugin manifest and makes the keep-alive discipline hook-enforced. This reverses the v0.17.0 documentation that described keep-alive as "best-effort / no registered Stop hook" - that is now inaccurate.

## Changes

- `plugins/credo/hooks/hooks.json` - register two additional hooks:
  - `Stop` -> `credo-autonomy-keepalive.sh` (blocks a stop in autonomous mode when no self-wake is scheduled and instructs the agent to call ScheduleWakeup)
  - second `UserPromptSubmit` entry -> `credo-autonomy-clear.sh` (a real user message turns autonomy off)
- Documentation flipped from best-effort to hook-enforced across README.md, plugins/credo/README.md, docs/credo-guide.md, skills/session-autonomous/SKILL.md, commands/session-autonomous.md, commands/psalm.md, plugin.yaml. Framed honestly: enforcement is a nudge (block + instruction), not a guarantee of infinite wakefulness; staying awake still relies on the agent calling ScheduleWakeup.
- Outdated header comments in the two now-registered hook scripts corrected ("registered" instead of "switchover phase pending"). No executable logic changed in any hook script.
- Version 0.18.0 (plugin.yaml and plugin.json).

## Safety (loop guard)

The Stop hook cannot spin forever:

- `stop_hook_active` guard (with a jq-free grep fallback): if the stop was itself continued by a Stop hook, it exits 0 - so at most ONE forced continuation per stop attempt.
- Future-wake check: once a wake is marked (`credo-wake-scheduled` in the future), the stop is allowed.
- Paused veto and flag-absent short-circuit: in a normal, non-autonomous session (no flag) the hook is a plain no-op stop; a deliberately paused run also stays inert.
- The Stop hook is never wired without the UserPromptSubmit clear hook, so a returning user's first message clears the flag and neutralizes any stale flag.

## Test plan

- 11/11 deterministic unit tests pass (isolated HOME): no-flag -> exit 0; flag + no wake -> exit 2; stop_hook_active=true -> exit 0; future wake -> exit 0; past wake -> exit 2; paused -> exit 0; clear on real prompt -> flag removed + paused; wake marker / task-notification / system-notification -> flag kept
- hooks.json validates (jq)
- All credo shell scripts parse (bash -n)
- No AI-trace characters in the diff
- Live acceptance after install: in a fresh autonomous session confirm the Stop hook blocks a wake-less stop, a scheduled wake lets it stop, a user message clears autonomy, and a normal session is unaffected

## Notes

- Hooks load at session start, so this takes effect after updating the plugin to 0.18.0 and restarting Claude.
- Wiki (Credo page autonomy section) updated separately to match.
