### PR TITLE
credo v0.19.0: config-driven task backend + setup coverage

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/commands/session-init.md
+++ b/plugins/credo/commands/session-init.md
@@ -31,6 +31,8 @@ Before ANY implementation action, ask yourself:
 **Forbidden without delegation:** Bash (for implementation), Write, Edit
 **Allowed directly:** Read, Glob, Grep (research), user questions, Skill tool
 
+**Respect the task backend:** it is set in `.credo/config` (`task_backend`) and can be overridden by the `CREDO_TASK_BACKEND` env var; resolve it with `${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh backend`. When it is `gsd`, GSD is the task system - do NOT create or move `.credo/items/`. When it is `credo` (the default) or `none`, the credo item workflow is active.
+
 ### Rule 2: Parallelization Analysis
 
 For every user prompt, immediately analyze:

--- a/plugins/credo/commands/setup.md
+++ b/plugins/credo/commands/setup.md
@@ -48,6 +48,8 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/credo-init.sh"
 
 This creates the `.credo/` structure (items, process, screenshots, checklists, config, id-counter) and adds the git-exclude lines. `.credo/**` stays local by default. For teams that want items and process versioned in the repo, run it with `CREDO_VERSION_TRACKED=1` instead (per-project `config` and `screenshots/` stay local either way).
 
+**Existing repository with prior work?** Instead of the fresh-init path above, run `/credo:migrate` once to onboard the existing codebase into the `.credo/` structure (it inventories current state and seeds items rather than assuming a blank slate).
+
 After this, credo's session modes, item lifecycle, Definition of Done, budget awareness, verify, and safety are ready. Pick a session mode when you start working:
 
 - `/credo:session-active` - intensive live collaboration.
@@ -205,7 +207,13 @@ credo's item lifecycle (from Step 2) is the recommended default and needs no fur
 
 **Only relevant if the user installed get-shit-done and prefers spec-driven planning.** Pick ONE task system per project (credo items OR GSD phases), never both, to avoid competing sources of truth.
 
-**If the user picks GSD as the task system:** advise them to set `CREDO_TASK_BACKEND=gsd` so credo's own item features stand down (no `.credo/items/` vs `.planning/` double-bookkeeping). credo's operating layer - session modes, budget, safety, verify, subagent priming - keeps working on top of GSD regardless. Leaving the variable unset (or `credo`) keeps credo items as the task system.
+**If the user picks GSD as the task system:** write `task_backend: gsd` into the project `.credo/config` for them (see "Writing the GSD backend" below) so credo's own item features stand down (no `.credo/items/` vs `.planning/` double-bookkeeping). credo's operating layer - session modes, budget, safety, verify, subagent priming - keeps working on top of GSD regardless. Leaving the config untouched (backend `credo`) keeps credo items as the task system, no action needed. The `CREDO_TASK_BACKEND` env var still overrides the config if ever needed.
+
+**Writing the GSD backend.** `.credo/config` already exists (credo-init created it in Step 2). Read it: if a top-level `task_backend:` line is present, update its value to `gsd`; otherwise append a `task_backend: gsd` line at the top level. Use Read + Edit (or Write) to make the change - do not shell out to a config setter. Example resulting line:
+
+```yaml
+task_backend: gsd
+```
 
 **Skip if:** GSD is not installed, OR `files.project_md = true`, OR `directories.codebase_map = true`, OR the user is happy with credo items.
 
@@ -219,7 +227,7 @@ You have get-shit-done installed. For this project, which task system?
 - GSD: run /gsd:new-project - up-front spec-driven planning (creates PROJECT.md)
 ```
 
-If user chooses GSD: Run `/gsd:new-project` via Skill tool, then advise setting `CREDO_TASK_BACKEND=gsd`.
+If user chooses GSD: Run `/gsd:new-project` via Skill tool, then write `task_backend: gsd` into `.credo/config` (see "Writing the GSD backend" above).
 
 **For EXISTING projects (project.is_greenfield = false):**
 
@@ -231,7 +239,7 @@ You have get-shit-done installed and existing code that hasn't been mapped.
 - GSD: run /gsd:map-codebase - analyze the codebase for spec-driven planning
 ```
 
-If user chooses GSD: Run `/gsd:map-codebase` via Skill tool, then advise setting `CREDO_TASK_BACKEND=gsd`.
+If user chooses GSD: Run `/gsd:map-codebase` via Skill tool, then write `task_backend: gsd` into `.credo/config` (see "Writing the GSD backend" above).
 
 ## Step 7: Create Roadmap (Optional, GSD only)
 

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -106,7 +106,7 @@ Honest note on keep-alive: autonomous mode sets the `credo-autonomy-active` flag
 
 ## 5. The item workflow: how-to
 
-**Task backend (`CREDO_TASK_BACKEND`).** credo's item model is the default task system, but it can stand down in favour of get-shit-done. The variable takes `credo` (default), `gsd`, or `none`; anything unset, empty, or unknown behaves like `credo`, so the default behaviour is unchanged.
+**Task backend (`.credo/config: task_backend`).** credo's item model is the default task system, but it can stand down in favour of get-shit-done. It is config-driven: set `task_backend` in `.credo/config` (via the config cascade builtin < global < project) to `credo` (default), `gsd`, or `none`. The `CREDO_TASK_BACKEND` env var overrides the config when set and non-empty. Anything unset, empty, or unknown behaves like `credo`, so the default behaviour is unchanged, and any resolution error falls back to `credo`. `/credo:setup` writes `task_backend: gsd` for you when you choose GSD.
 
 - `credo` (or unset / `none`) - the item lifecycle below is active. `credo-init.sh` creates the `items/` tree and id-counter, and the subagent priming tells delegated agents to record and gate work as credo items.
 - `gsd` - the credo item model stands down: `credo-init.sh` skips the `items/` tree and id-counter, the subagent priming drops the item/audit sentence, and the items/audit/verify skills note that they do not gate credo items. GSD's phases own task tracking; set this when you run GSD as the task system so there is no `.credo/items/` vs `.planning/` double-bookkeeping. The operating layer (session modes, budget, safety, verify, subagent priming) stays on regardless.

--- a/plugins/credo/hooks/credo-subagent-inject.sh
+++ b/plugins/credo/hooks/credo-subagent-inject.sh
@@ -50,11 +50,14 @@ The relevant credo skills above auto-trigger when they apply - use them.
 RULES
 
 # --- task-backend gate (fail-safe) ---
-# CREDO_TASK_BACKEND=credo|gsd|none. Default (unset/empty/unknown) behaves like credo,
-# so the previous behaviour is unchanged. Only backend=gsd stands the credo item model
-# down: the item/audit sentence is dropped from the priming. Security, quality (verify),
+# Resolved via credo-config.sh: env CREDO_TASK_BACKEND override (set + non-empty)
+# > merged config task_backend (.credo/config cascade) > credo default. Any error
+# falls back to credo. Only backend=gsd stands the credo item model down: the
+# item/audit sentence is dropped from the priming. Security, quality (verify),
 # honesty, delegation, and output-hygiene rules ALWAYS stay in - they are unconditional.
-backend="${CREDO_TASK_BACKEND:-credo}"
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || HOOK_DIR=""
+backend="$("$HOOK_DIR/../scripts/credo-config.sh" backend 2>/dev/null || echo credo)"
+[[ -n "$backend" ]] || backend="credo"
 if [[ "$backend" == "gsd" ]]; then
     item_clause=""
 else

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.18.0
+version: 0.19.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/scripts/check-setup.sh
+++ b/plugins/credo/scripts/check-setup.sh
@@ -74,6 +74,24 @@ if [ "$CURL_INSTALLED" = "false" ]; then
     MISSING_WARNINGS="${MISSING_WARNINGS}  - curl: limit (install: sudo apt install curl)\n"
 fi
 
+# Active task backend (resolved, fail-safe)
+# Resolver: env CREDO_TASK_BACKEND override > .credo/config task_backend > credo.
+# unset/empty/credo/none -> credo items active; exactly "gsd" -> credo items stand down.
+CHECK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null)" || CHECK_DIR="."
+RESOLVED_BACKEND="$("$CHECK_DIR/credo-config.sh" backend 2>/dev/null || echo credo)"
+[ -n "$RESOLVED_BACKEND" ] || RESOLVED_BACKEND="credo"
+case "$RESOLVED_BACKEND" in
+    gsd)
+        TASK_BACKEND_REPORT="gsd (credo items stand down)"
+        ;;
+    none)
+        TASK_BACKEND_REPORT="credo (none set - items active)"
+        ;;
+    *)
+        TASK_BACKEND_REPORT="credo (items active)"
+        ;;
+esac
+
 # Output structured results
 cat <<EOF
 CREDO_SETUP_CHECK_V1
@@ -98,6 +116,7 @@ project:
   file_count: $FILE_COUNT
   is_greenfield: $IS_GREENFIELD
   state: $PROJECT_STATE
+task_backend: $TASK_BACKEND_REPORT
 EOF
 
 # Output warnings for missing requirements

--- a/plugins/credo/scripts/credo-config.sh
+++ b/plugins/credo/scripts/credo-config.sh
@@ -13,6 +13,7 @@
 #
 # Usage:
 #   credo-config.sh get <dotted.key>   print merged value (exit 3 if absent)
+#   credo-config.sh backend            print resolved task backend (fail-safe)
 #   credo-config.sh ensure-global      create global config if missing
 #   credo-config.sh paths              print the three layer paths + existence
 #
@@ -66,6 +67,24 @@ ensure_global() {
 CMD="${1:-}"
 
 case "$CMD" in
+    backend)
+        # Resolve the task backend. Fail-safe: always prints a value, never exits
+        # non-zero for a missing key. Precedence:
+        #   1. env CREDO_TASK_BACKEND set AND non-empty -> use it (override)
+        #   2. merged config task_backend (via the cascade)
+        #   3. credo (default)
+        if [ -n "${CREDO_TASK_BACKEND:-}" ]; then
+            printf '%s\n' "$CREDO_TASK_BACKEND"
+            exit 0
+        fi
+        val="$("${BASH_SOURCE[0]}" get task_backend 2>/dev/null)" || val=""
+        if [ -n "$val" ]; then
+            printf '%s\n' "$val"
+        else
+            printf '%s\n' "credo"
+        fi
+        exit 0
+        ;;
     ensure-global)
         ensure_global && echo "$GLOBAL"
         ;;
@@ -259,7 +278,7 @@ else:
 PY
         ;;
     ""|-h|--help|help)
-        echo "usage: credo-config.sh {get <key>|ensure-global|paths}" >&2
+        echo "usage: credo-config.sh {get <key>|backend|ensure-global|paths}" >&2
         [ -z "$CMD" ] && exit 1 || exit 0
         ;;
     *)

--- a/plugins/credo/scripts/credo-init.sh
+++ b/plugins/credo/scripts/credo-init.sh
@@ -13,6 +13,8 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # --- locate the target .credo directory -------------------------------------
 # Precedence: explicit CREDO_DIR > git toplevel/.credo > ./.credo
 if [ -n "${CREDO_DIR:-}" ]; then
@@ -24,11 +26,16 @@ else
 fi
 
 # --- task backend (fail-safe) ------------------------------------------------
-# CREDO_TASK_BACKEND=credo|gsd|none. Default (unset/empty/unknown) behaves like credo,
-# so the previous behaviour is unchanged. Only backend=gsd skips the item/ subtree and
-# id-counter, because with GSD as the task system the .credo/items/ model stands down and
-# the base tree (docs, screenshots, process, checklists, config) is all that is needed.
-BACKEND="${CREDO_TASK_BACKEND:-credo}"
+# Resolved via credo-config.sh: env CREDO_TASK_BACKEND override (set + non-empty)
+# > merged config task_backend (.credo/config cascade) > credo default. Any error
+# falls back to credo. Chicken-and-egg is fine: when this runs before any project
+# config exists, the resolver falls back to global/builtin (task_backend: credo) and
+# the items tree is created (correct default). Only backend=gsd skips the item/
+# subtree and id-counter, because with GSD as the task system the .credo/items/ model
+# stands down and the base tree (docs, screenshots, process, checklists, config) is all
+# that is needed.
+BACKEND="$("$SCRIPT_DIR/credo-config.sh" backend 2>/dev/null || echo credo)"
+[ -n "$BACKEND" ] || BACKEND="credo"
 
 # --- directory structure -----------------------------------------------------
 DIRS=(

--- a/plugins/credo/skills/audit/SKILL.md
+++ b/plugins/credo/skills/audit/SKILL.md
@@ -10,7 +10,7 @@ judges whether it actually satisfies its stated requirement and Definition of Do
 BEFORE the item is allowed into `2_done/`. The output is a decision proposal for the
 user, never a change.
 
-> **Task backend.** If `CREDO_TASK_BACKEND=gsd`, the credo item lifecycle is inactive and
+> **Task backend.** If the task backend is `gsd` (`.credo/config: task_backend`, or the `CREDO_TASK_BACKEND` env override), the credo item lifecycle is inactive and
 > there is no `2_done/` gate to run - GSD owns task tracking. audit is still usable as a
 > standalone read-only review tool, but it does not gate credo items in that mode.
 

--- a/plugins/credo/skills/items/SKILL.md
+++ b/plugins/credo/skills/items/SKILL.md
@@ -18,7 +18,7 @@ task-tracker entry - an item changes status by physically moving between folders
 deliberate anti-drift: multiple status sources drift out of sync, one physical location
 cannot. `.credo/items/` IS the task system; do not mirror items into a separate task list.
 
-> **Task backend.** If `CREDO_TASK_BACKEND=gsd`, the credo item system is inactive - GSD's
+> **Task backend.** If the task backend is `gsd` (set in `.credo/config` as `task_backend`, or via the `CREDO_TASK_BACKEND` env override; resolve with `credo-config.sh backend`), the credo item system is inactive - GSD's
 > phases are the task system for this project. Do NOT create or move `.credo/items/`; use
 > GSD's workflow instead. This skill applies only when the backend is `credo` (the default)
 > or `none`.

--- a/plugins/credo/skills/verify/SKILL.md
+++ b/plugins/credo/skills/verify/SKILL.md
@@ -18,7 +18,7 @@ user action, it is not done until that behavior has been observed - either by th
 in a real browser, or by a reliable automated Playwright check that drives the real
 build. This skill is the DoD gate that `ui: true` items require.
 
-> **Task backend.** If `CREDO_TASK_BACKEND=gsd`, the credo item lifecycle is inactive, so
+> **Task backend.** If the task backend is `gsd` (`.credo/config: task_backend`, or the `CREDO_TASK_BACKEND` env override), the credo item lifecycle is inactive, so
 > there is no credo item to move to done - GSD owns task tracking. The verification method
 > here still applies as a general "prove it renders" tool; just do not gate a credo item
 > with it in that mode.

--- a/plugins/credo/templates/config.default.yaml
+++ b/plugins/credo/templates/config.default.yaml
@@ -9,6 +9,15 @@
 # that need them (permission per change). Never put personal values or absolute
 # machine paths into this shipped template.
 
+# --- task backend ------------------------------------------------------------
+# Which task system credo runs on. Core project choice.
+#   credo (default) - credo's item lifecycle is active.
+#   gsd             - the credo item model stands down (get-shit-done owns tasks).
+#   none            - same as credo (items active).
+# Anything unset, empty, or unknown behaves like credo, so the default is safe.
+# The CREDO_TASK_BACKEND env var overrides this value when set and non-empty.
+task_backend: credo
+
 # --- visual verify -----------------------------------------------------------
 verify:
   # Fixed viewport widths (px) for visual verification.


### PR DESCRIPTION
## Summary

Makes the credo task backend config-driven so a user who chooses GSD does not have to set anything by hand - `/credo:setup` writes the choice for them. Also closes the setup-coverage gaps for `/credo:migrate`. Builds on v0.18.0 (which wired the autonomy keep-alive hooks).

## Changes

- **Config-driven backend**: `task_backend` is now a field in `.credo/config` (default `credo`), read through the existing config cascade (builtin < global < project). A new `credo-config.sh backend` resolver returns: `CREDO_TASK_BACKEND` env var if set (override) > config value > `credo`. It always prints a value and never errors (fail-safe).
- The gating scripts (`credo-subagent-inject.sh`, `credo-init.sh`) and `check-setup.sh` now use the resolver instead of reading the env var directly. Only the exact value `gsd` stands the credo item model down; every other value keeps items active. Safety/quality/honesty injection stays unconditional.
- **Setup writes it for the user**: `/credo:setup` Step 6, when the user picks GSD, writes `task_backend: gsd` into `.credo/config` (the env var still overrides if ever needed). The credo default requires no action.
- **Model-facing guidance made config-aware**: `session-init.md` and the `items` / `audit` / `verify` skills now point at the resolved backend (`.credo/config: task_backend`, env override) instead of the env var alone, so the model's view matches the scripts.
- **Setup coverage**: `setup.md` documents `/credo:migrate` for onboarding an existing repo; `check-setup.sh` reports the resolved task backend; `credo-guide.md` describes the backend as config-driven.
- Version 0.19.0.

## Test plan

- Resolver unit cases (isolated config/env): no config -> credo; project `task_backend: gsd` -> gsd; env override beats config both ways; broken/unreadable config -> credo (fail-safe); empty env is not an override
- credo-init gating: `gsd` skips the items tree and id-counter (base tree still created); default creates them; safe when no project config exists yet
- credo-subagent-inject under `gsd` still emits valid JSON with all safety/quality/honesty lines; only the item/audit clause is dropped
- bash -n passes on all touched scripts; both version files at 0.19.0; no AI-trace characters in the diff

## Notes

- Takes effect after updating the plugin to 0.19.0 and restarting Claude (config is read at runtime by the hooks).
- Wiki updated separately if needed.
