### PR TITLE
credo v0.20.0: cwd-aware project resolution (hub guard, session pin)

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/commands/project.md
+++ b/plugins/credo/commands/project.md
@@ -1,0 +1,54 @@
+---
+description: credo - Pin the target repo for credo's project layer (hub-aware), or show the resolved target
+arguments:
+  - name: path
+    description: Absolute path of the repo to target with credo (omit to show the current target)
+    required: false
+allowed-tools:
+  - Bash(${CLAUDE_PLUGIN_ROOT}/hooks/session-project-set.sh:*)
+  - Bash(${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh:*)
+  - AskUserQuestion
+---
+
+# Credo Project Target
+
+credo has two layers. The AUTONOMY layer (keep-alive flags) is global to your user
+and is never changed here. This command only sets the PROJECT layer: which repo's
+`.credo/`, config, and items credo operates on.
+
+Why this exists: when your shell cwd is a launch hub (a directory you start other
+repos from) rather than the repo you are actually working on, credo would otherwise
+resolve its project layer to the wrong place. Pin the real target instead.
+
+## With an argument (set the pin)
+
+The user gave a path in `$ARGUMENTS`.
+
+1. Pin it for this session:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/hooks/session-project-set.sh" "$ARGUMENTS"
+   ```
+   The script validates that the path is an existing directory and keys the pin by
+   the current session_id. If it errors (path missing, no session_id), report the
+   message verbatim and stop - do not guess a path.
+2. Confirm the resolved target:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" resolve-project
+   ```
+3. Confirm briefly: credo now targets `<resolved .credo dir>` for this session.
+
+## Without an argument (show the current target)
+
+1. Resolve the current target and capture the exit code:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" resolve-project; echo "rc=$?"
+   ```
+2. Check whether the cwd is a hub:
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" is-hub
+   ```
+3. Report:
+   - exit 0: credo targets the printed `.credo` directory.
+   - exit 4: no target resolved - the cwd is a hub (`is-hub` = true) or has no
+     credo project yet. Tell the user to pin a repo with `/credo:project <path>`
+     or set `CREDO_DIR`, then retry whatever needed the target.

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -88,6 +88,8 @@ The path of an item:
 
 To onboard an existing repository into this structure, run `/credo:migrate` - it sets up `.credo/` and walks the repo through the migration procedure once.
 
+credo targets the repo you point it at (hub-aware): when your shell cwd is a launch hub rather than the repo you are working on, pin the real target with `/credo:project <path>` so the item tree and config resolve to the right place. A directory marked `hub: true` is never auto-targeted.
+
 **The Definition of Done is hard:** success criteria observably met, code wired in, an independent audit subagent (not the builder) passed it, UI work visually verified in a real browser with screenshot evidence, and docs updated in the same change. "The test passed" is not done.
 
 ### Topic: Budget and Autonomy
@@ -113,6 +115,7 @@ Two orchestration skills for maintaining a public repo. They trigger on their ow
 | --------------------------- | -------------------------------------------------------------- |
 | `/credo:setup`              | Initialize the framework and offer recommended/optional tools  |
 | `/credo:migrate`            | Migrate an existing repo into the `.credo/` structure          |
+| `/credo:project`            | Pin the active repo credo targets (hub-aware) or show it       |
 | `/credo:psalm`              | This guide - credo topics first, then the wider marketplace    |
 | `/credo:session-init`       | Load the main-agent delegation-first workflow                  |
 | `/credo:session-active`     | Set the session to active (live collaboration)                 |

--- a/plugins/credo/commands/setup.md
+++ b/plugins/credo/commands/setup.md
@@ -48,6 +48,40 @@ bash "${CLAUDE_PLUGIN_ROOT}/scripts/credo-init.sh"
 
 This creates the `.credo/` structure (items, process, screenshots, checklists, config, id-counter) and adds the git-exclude lines. `.credo/**` stays local by default. For teams that want items and process versioned in the repo, run it with `CREDO_VERSION_TRACKED=1` instead (per-project `config` and `screenshots/` stay local either way).
 
+### Handling the target guard (fail-safe)
+
+credo-init is fail-safe: it never creates `.credo/` in the wrong place. If the current directory is a launch hub, or is ambiguous (no `.credo/` yet and no explicit target given), the script exits non-zero (code 4) with a message like:
+
+```
+credo-init: cwd '<path>' is a hub or has no credo project, and no explicit target was given.
+Set CREDO_DIR to the target repo, or pin it with /credo:project <path>, then retry.
+```
+
+**If you see this (a non-zero exit), do NOT force a directory.** The user must not have to know about env vars or config keys - guide them with AskUserQuestion:
+
+```
+credo could not decide which repo to target from here.
+
+Where should credo set up its project layer (.credo/)?
+- This directory - the current working directory IS the repo I want credo in
+- Another repo - I will give you the absolute path of the target repo
+- This is a launch hub - I start other repos from here; never auto-target it
+```
+
+Then act on the answer:
+
+- **This directory:** re-run init pinned to the cwd, which creates `.credo/` here:
+  ```bash
+  CREDO_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)/.credo" bash "${CLAUDE_PLUGIN_ROOT}/scripts/credo-init.sh"
+  ```
+- **Another repo:** ask for the absolute path, pin it, then re-run init:
+  ```bash
+  "${CLAUDE_PLUGIN_ROOT}/hooks/session-project-set.sh" "<abs-path>"
+  bash "${CLAUDE_PLUGIN_ROOT}/scripts/credo-init.sh"
+  ```
+  (The pin is layer 2 of the resolver, so plain `credo-init.sh` now finds the target.)
+- **This is a launch hub:** mark the cwd as a hub so credo never auto-targets it. Write `hub: true` at the top level of `<cwd>/.credo/config` (create the file if missing) with Read + Edit or Write, then tell the user to pin the real repo with `/credo:project <path>` whenever they work. Do NOT create the full `.credo/` item tree here - a hub is not a work repo.
+
 **Existing repository with prior work?** Instead of the fresh-init path above, run `/credo:migrate` once to onboard the existing codebase into the `.credo/` structure (it inventories current state and seeds items rather than assuming a blank slate).
 
 After this, credo's session modes, item lifecycle, Definition of Done, budget awareness, verify, and safety are ready. Pick a session mode when you start working:

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -18,7 +18,7 @@ Design principles:
 
 ### 2.1 Components
 
-- **commands/** - six slash commands: `psalm`, `setup`, `session-init`, and the three mode setters `session-active`, `session-passive`, `session-autonomous`.
+- **commands/** - eight slash commands: `psalm`, `setup`, `migrate`, `project`, `session-init`, and the three mode setters `session-active`, `session-passive`, `session-autonomous`.
 - **skills/** - fourteen auto-discovered skills (see section 6). Each auto-triggers when it applies, including inside subagents.
 - **hooks/** - four hooks are registered in `hooks/hooks.json`:
   - `session-mode-inject.sh` (`UserPromptSubmit`) - re-injects the active session mode on every prompt and names the skill to load.
@@ -26,7 +26,7 @@ Design principles:
   - `credo-subagent-inject.sh` (`SubagentStart`) - primes every subagent with the load-bearing rules.
   - `credo-autonomy-keepalive.sh` (`Stop`) - in autonomous mode, blocks a stop that has no scheduled self-wake and instructs the agent to call ScheduleWakeup.
 
-  The remaining autonomy scripts (`credo-autonomy-on.sh`, `credo-autonomy-off.sh`, `credo-autonomy-wake-mark.sh`) and `session-mode-set.sh` are plain helper scripts invoked by the session commands and skills - they are NOT hooks. Because the `Stop` and second `UserPromptSubmit` hooks are now wired into `hooks.json`, autonomous keep-alive is hook-enforced at runtime (loop-safe, and inert outside autonomy - see section 4).
+  The remaining autonomy scripts (`credo-autonomy-on.sh`, `credo-autonomy-off.sh`, `credo-autonomy-wake-mark.sh`), `session-mode-set.sh`, and `session-project-set.sh` are plain helper scripts invoked by the session commands and skills - they are NOT hooks. Because the `Stop` and second `UserPromptSubmit` hooks are now wired into `hooks.json`, autonomous keep-alive is hook-enforced at runtime (loop-safe, and inert outside autonomy - see section 4).
 - **scripts/** - `check-setup.sh`, `credo-init.sh`, `credo-id-next.sh`, `credo-config.sh`, `credo-budget-read.sh`, `credo-item-move.sh`.
 - **templates/** - `config.default.yaml` (builtin config defaults) and `item.template.md` (the work-item template).
 
@@ -91,6 +91,23 @@ Personal fields under `personal:` (ntfy topic, commit-identity hint, WSL `lan_ip
 ### 3.2 Deterministic id-counter
 
 `scripts/credo-id-next.sh` owns id allocation. The counter file holds the last id given out. Allocation is atomic under flock: read (0 if empty), increment, write, print. It never scans folders to choose a number, so a deleted item id is never reused. A recovery fallback (max existing id plus one) applies only if the counter file is missing. Never derive an id from folder contents; always call the helper.
+
+### 3.3 Project resolution (hub-aware)
+
+The PROJECT layer (`.credo/`, config, items) is resolved by one shared function, `scripts/credo-config.sh resolve-project`, used by `credo-init.sh` (where to create/operate) and `check-setup.sh` (reporting). This is separate from the AUTONOMY layer, which is HOME-global keep-alive state and is never affected by project resolution. Precedence:
+
+1. `CREDO_DIR` env (explicit) - use it.
+2. Session pin, if set and resolvable - use it (see below).
+3. cwd git-toplevel (or cwd if not in a repo):
+   - if that directory's OWN project config (`<dir>/.credo/config`) has `hub: true` - it is a launch hub, so credo does NOT auto-target it and signals "needs explicit target";
+   - else if `<dir>/.credo/` already exists - use it (established project);
+   - else (a new `.credo` would be created and no explicit target was given) - signal "needs explicit target".
+
+The `hub` flag is read from the PROJECT layer file directly (that dir's `.credo/config`), never the merged cascade, so a global default can never mark every directory a hub.
+
+`resolve-project` prints the target `.credo` directory and exits 0, or prints nothing and exits 4 ("needs explicit target", distinct from the 1/3 codes of `get`). When it signals 4, `credo-init.sh` creates nothing and exits 4 with an actionable message; this is fail-safe and non-interactive-safe (it fails rather than creating `.credo/` in the wrong place). The config-READ path (`get`, `backend`) is unchanged and still falls back to the builtin defaults for the normal case.
+
+**Session pin (`/credo:project`).** When the shell cwd is a launch hub rather than the repo you are working on, pin the real target with `/credo:project <abs-path>`. This mirrors the session-mode mechanic: `hooks/session-project-set.sh` writes the absolute repo path atomically to a file keyed by session_id under `${CREDO_SESSION_PROJECTS_DIR:-$HOME/.claude/credo/session-projects}/<session_id>`. The session_id is resolved as arg > `$CREDO_SESSION_ID` > `$CLAUDE_CODE_SESSION_ID`. The resolver reads the pin as layer 2; a missing or unresolvable pin never errors the resolver, it just falls through to layer 3. `/credo:project` without an argument reports the resolved target and whether the cwd is a hub. Mark a hub by setting `hub: true` in that directory's own `.credo/config`.
 
 ## 4. Session modes: how-to
 

--- a/plugins/credo/hooks/session-project-set.sh
+++ b/plugins/credo/hooks/session-project-set.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# session-project-set.sh <abs-path> [session_id]
+#
+# Pin the target repo for credo's PROJECT layer (.credo, config, items) for this
+# session. This is layer 2 of `credo-config.sh resolve-project`: it lets a launch
+# hub (a shell cwd you start other repos from) point credo at the repo you are
+# actually working on, without changing the cwd or exporting CREDO_DIR by hand.
+#
+# The absolute target repo path is written atomically (tmp + mv -f) to a file
+# keyed by session_id under the session-projects dir. Mirrors session-mode-set.sh.
+# The session_id is resolved in this order:
+#   1. the second positional argument (if given)
+#   2. $CREDO_SESSION_ID       (test / manual override)
+#   3. $CLAUDE_CODE_SESSION_ID (set by Claude Code for tool bash calls)
+# Without a session_id the pin cannot be keyed -> hard error (no write).
+#
+# Fail-safe messaging: a non-existent path or a bad session_id is rejected with a
+# clear message and a non-zero exit; nothing is written on error.
+set -u
+
+target="${1:-}"
+if [ -z "$target" ]; then
+    echo "Usage: session-project-set.sh <path> [session_id]" >&2
+    exit 1
+fi
+if [ ! -d "$target" ]; then
+    echo "session-project-set: not an existing directory: $target" >&2
+    exit 1
+fi
+target_abs="$(cd "$target" 2>/dev/null && pwd)" || {
+    echo "session-project-set: cannot resolve directory: $target" >&2
+    exit 1
+}
+
+session_id="${2:-${CREDO_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}}"
+if [ -z "$session_id" ]; then
+    echo "session-project-set: cannot determine session_id (pass it as arg 2 or set CLAUDE_CODE_SESSION_ID)" >&2
+    exit 1
+fi
+case "$session_id" in
+    *[!A-Za-z0-9._-]*)
+        echo "session-project-set: invalid session_id (unexpected characters)" >&2
+        exit 1
+        ;;
+esac
+
+STATE_DIR="${CREDO_SESSION_PROJECTS_DIR:-$HOME/.claude/credo/session-projects}"
+mkdir -p "$STATE_DIR" || { echo "session-project-set: cannot create state dir $STATE_DIR" >&2; exit 1; }
+
+state_file="$STATE_DIR/$session_id"
+tmp="$(mktemp "${state_file}.XXXXXX")" || { echo "session-project-set: mktemp failed" >&2; exit 1; }
+printf '%s\n' "$target_abs" > "$tmp"
+mv -f "$tmp" "$state_file"
+
+echo "credo project pinned = $target_abs (session $session_id)"

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.19.0
+version: 0.20.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 
@@ -14,6 +14,9 @@ commands:
   migrate:
     description: Migrate an existing repo into the .credo/ structure
     source: commands/migrate.md
+  project:
+    description: Pin the target repo for credo's project layer (hub-aware), or show the resolved target
+    source: commands/project.md
   session-init:
     description: Initialize session with main agent workflow instructions
     source: commands/session-init.md

--- a/plugins/credo/scripts/check-setup.sh
+++ b/plugins/credo/scripts/check-setup.sh
@@ -92,6 +92,19 @@ case "$RESOLVED_BACKEND" in
         ;;
 esac
 
+# Resolved credo project dir + hub state (fail-safe, additive report)
+# Reuses credo-config.sh resolve-project: prints the target .credo dir, or the
+# needs_explicit_target state when the cwd is a hub or has no credo project.
+CREDO_PROJECT_RESOLVED="$("$CHECK_DIR/credo-config.sh" resolve-project 2>/dev/null)"
+CREDO_PROJECT_RC=$?
+CREDO_CWD_IS_HUB="$("$CHECK_DIR/credo-config.sh" is-hub 2>/dev/null || echo false)"
+[ -n "$CREDO_CWD_IS_HUB" ] || CREDO_CWD_IS_HUB="false"
+if [ "$CREDO_PROJECT_RC" -eq 0 ] && [ -n "$CREDO_PROJECT_RESOLVED" ]; then
+    CREDO_PROJECT_REPORT="$CREDO_PROJECT_RESOLVED"
+else
+    CREDO_PROJECT_REPORT="needs_explicit_target"
+fi
+
 # Output structured results
 cat <<EOF
 CREDO_SETUP_CHECK_V1
@@ -117,6 +130,9 @@ project:
   is_greenfield: $IS_GREENFIELD
   state: $PROJECT_STATE
 task_backend: $TASK_BACKEND_REPORT
+credo_project:
+  resolved: $CREDO_PROJECT_REPORT
+  cwd_is_hub: $CREDO_CWD_IS_HUB
 EOF
 
 # Output warnings for missing requirements

--- a/plugins/credo/scripts/credo-config.sh
+++ b/plugins/credo/scripts/credo-config.sh
@@ -16,15 +16,22 @@
 #   credo-config.sh backend            print resolved task backend (fail-safe)
 #   credo-config.sh ensure-global      create global config if missing
 #   credo-config.sh paths              print the three layer paths + existence
+#   credo-config.sh resolve-project    print the target .credo dir (exit 4 if a
+#                                       hub or ambiguous cwd needs an explicit target)
+#   credo-config.sh is-hub             print true/false: is the cwd repo a hub
 #
 # Env overrides (mainly for testing):
-#   CLAUDE_PLUGIN_ROOT  plugin root (locates the builtin template)
-#   CREDO_GLOBAL        path to the global config file
-#   CREDO_PROJECT       path to the project config file
-#   CREDO_DIR           project .credo dir (project config = $CREDO_DIR/config)
-#   CREDO_SKIP_ENSURE   if set to 1, "get" does not auto-create the global layer
+#   CLAUDE_PLUGIN_ROOT        plugin root (locates the builtin template)
+#   CREDO_GLOBAL              path to the global config file
+#   CREDO_PROJECT             path to the project config file
+#   CREDO_DIR                 project .credo dir (project config = $CREDO_DIR/config)
+#   CREDO_SKIP_ENSURE         if set to 1, "get" does not auto-create the global layer
+#   CREDO_SESSION_PROJECTS_DIR session-pin dir (default ~/.claude/credo/session-projects)
+#   CREDO_SESSION_ID           session id for the pin lookup (test override)
+#   CLAUDE_CODE_SESSION_ID     session id for the pin lookup (set by Claude Code)
 #
-# Exit codes: 0 ok, 1 hard error, 3 key not found.
+# Exit codes: 0 ok, 1 hard error, 3 key not found, 4 needs explicit target
+#   (resolve-project only: cwd is a hub or has no credo project).
 
 set -euo pipefail
 
@@ -62,6 +69,47 @@ ensure_global() {
     local tmp="$GLOBAL.tmp.$$"
     cp "$BUILTIN" "$tmp"
     mv -f "$tmp" "$GLOBAL"
+}
+
+# --- read the top-level `hub` flag from ONE project config file directly ------
+# The hub flag is deliberately read from the PROJECT layer file only (that dir's
+# .credo/config), NOT the merged cascade, so a global default can never mark
+# every directory a hub. Missing file / key -> false.
+read_hub() {
+    local f="$1"
+    python3 - "$f" <<'PY'
+import sys
+path = sys.argv[1]
+val = False
+try:
+    with open(path, encoding="utf-8") as fh:
+        for raw in fh:
+            line = raw.rstrip("\n")
+            # top-level only: skip indented lines, comments and blanks
+            if line[:1] in (" ", "\t", "#", ""):
+                continue
+            if ":" not in line:
+                continue
+            k, _, v = line.partition(":")
+            if k.strip() != "hub":
+                continue
+            v = v.split("#", 1)[0].strip().strip('"').strip("'").lower()
+            val = v in ("true", "yes", "on", "1")
+            break
+except OSError:
+    pass
+print("true" if val else "false")
+PY
+}
+
+# --- resolve the repo base for cwd-based lookups (git toplevel or cwd) --------
+cwd_base() {
+    local top
+    if top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        printf '%s\n' "$top"
+    else
+        pwd
+    fi
 }
 
 CMD="${1:-}"
@@ -277,8 +325,54 @@ else:
     print(node)
 PY
         ;;
+    resolve-project)
+        # Resolve the target .credo directory for credo-init / reporting.
+        # Precedence:
+        #   1. CREDO_DIR env (explicit)              -> print it.
+        #   2. session pin (per session_id)          -> print <pin>/.credo.
+        #   3. cwd git-toplevel (or cwd):
+        #        - PROJECT-layer hub: true           -> exit 4 (needs target).
+        #        - <base>/.credo/ exists             -> print it.
+        #        - otherwise (would create a new one) -> exit 4 (needs target).
+        # Exit 4 = "needs explicit target" (distinct from 1/3). Never errors out
+        # because of a missing pin; it just falls through to layer 3.
+        if [ -n "${CREDO_DIR:-}" ]; then
+            printf '%s\n' "$CREDO_DIR"
+            exit 0
+        fi
+        pin_sid="${CREDO_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
+        if [ -n "$pin_sid" ]; then
+            case "$pin_sid" in
+                *[!A-Za-z0-9._-]*) : ;;   # invalid session id -> skip the pin
+                *)
+                    pin_root="${CREDO_SESSION_PROJECTS_DIR:-$HOME/.claude/credo/session-projects}"
+                    pin_file="$pin_root/$pin_sid"
+                    if [ -f "$pin_file" ]; then
+                        pinned="$(sed -n '1p' "$pin_file" 2>/dev/null | tr -d '\r')"
+                        if [ -n "$pinned" ] && [ -d "$pinned" ]; then
+                            printf '%s\n' "$pinned/.credo"
+                            exit 0
+                        fi
+                    fi
+                    ;;
+            esac
+        fi
+        base="$(cwd_base)"
+        if [ "$(read_hub "$base/.credo/config")" = "true" ]; then
+            exit 4
+        fi
+        if [ -d "$base/.credo" ]; then
+            printf '%s\n' "$base/.credo"
+            exit 0
+        fi
+        exit 4
+        ;;
+    is-hub)
+        base="$(cwd_base)"
+        read_hub "$base/.credo/config"
+        ;;
     ""|-h|--help|help)
-        echo "usage: credo-config.sh {get <key>|backend|ensure-global|paths}" >&2
+        echo "usage: credo-config.sh {get <key>|backend|ensure-global|paths|resolve-project|is-hub}" >&2
         [ -z "$CMD" ] && exit 1 || exit 0
         ;;
     *)

--- a/plugins/credo/scripts/credo-init.sh
+++ b/plugins/credo/scripts/credo-init.sh
@@ -9,21 +9,34 @@
 #   credo-init.sh                 operate on the current git repo (or cwd)
 #   CREDO_DIR=/path credo-init.sh operate on an explicit .credo directory
 #
-# Exit codes: 0 on success, 1 on hard error.
+# Target resolution is delegated to `credo-config.sh resolve-project` so init and
+# config agree. It is fail-safe: when the cwd is a launch hub or has no credo
+# project and no explicit target was given, init creates NOTHING and exits 4.
+#
+# Exit codes: 0 on success, 1 on hard error, 4 needs explicit target.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# --- locate the target .credo directory -------------------------------------
-# Precedence: explicit CREDO_DIR > git toplevel/.credo > ./.credo
-if [ -n "${CREDO_DIR:-}" ]; then
-    CREDO_DIR="$CREDO_DIR"
-elif REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-    CREDO_DIR="$REPO_ROOT/.credo"
-else
-    CREDO_DIR="$(pwd)/.credo"
+# --- locate the target .credo directory (shared resolver) -------------------
+# Precedence (see credo-config.sh resolve-project): explicit CREDO_DIR > session
+# pin (/credo:project) > cwd git-toplevel/.credo when it already exists and is not
+# a hub. A new .credo is only ever created when an explicit target is given.
+set +e
+RESOLVED="$("$SCRIPT_DIR/credo-config.sh" resolve-project 2>/dev/null)"
+RESOLVE_RC=$?
+set -e
+if [ "$RESOLVE_RC" -eq 4 ]; then
+    TARGET_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    echo "credo-init: cwd '$TARGET_DIR' is a hub or has no credo project, and no explicit target was given. Set CREDO_DIR to the target repo, or pin it with /credo:project <path>, then retry." >&2
+    exit 4
 fi
+if [ "$RESOLVE_RC" -ne 0 ] || [ -z "$RESOLVED" ]; then
+    echo "credo-init: could not resolve a target .credo directory" >&2
+    exit 1
+fi
+CREDO_DIR="$RESOLVED"
 
 # --- task backend (fail-safe) ------------------------------------------------
 # Resolved via credo-config.sh: env CREDO_TASK_BACKEND override (set + non-empty)

--- a/plugins/credo/templates/config.default.yaml
+++ b/plugins/credo/templates/config.default.yaml
@@ -9,6 +9,14 @@
 # that need them (permission per change). Never put personal values or absolute
 # machine paths into this shipped template.
 
+# --- project targeting (hub guard) -------------------------------------------
+# hub: true  -> this directory is a launch hub; credo never auto-targets its .credo,
+#               an explicit target (CREDO_DIR or /credo:project) is always required.
+# This flag is read from THIS directory's own .credo/config only (the project layer),
+# never the merged cascade, so it can never leak from a global default. Leave it unset
+# (the shipped default) for normal repos where credo operates in place.
+# hub: true
+
 # --- task backend ------------------------------------------------------------
 # Which task system credo runs on. Core project choice.
 #   credo (default) - credo's item lifecycle is active.


### PR DESCRIPTION
## Summary

Makes credo's PROJECT layer (`.credo/`, config, items) resolve to the correct repo when the shell cwd is a launch hub rather than the repo being edited. The AUTONOMY layer (HOME-global keep-alive flags) is unchanged. Solves the "work on repo X from a shared hub directory" case without the user having to manage environment variables.

## Changes

- **Resolution chain** (shared logic in `credo-config.sh`, used by `credo-init.sh` and `check-setup.sh`): `CREDO_DIR` env > session pin > current repo (git top-level). The `hub` flag is read from the PROJECT-layer `.credo/config` directly (not the merged cascade).
- **Guard**: a new `.credo/` is never created silently at a hub or an ambiguous location. `credo-config.sh resolve-project` returns exit code 4 (needs-target, nothing on stdout); `credo-init.sh` then creates nothing and exits 4 with an actionable message. Fail-safe and non-interactive-safe.
- **Hub concept**: a directory marks itself a hub with `hub: true` in its `.credo/config`. A hub's own `.credo/` is never auto-targeted - an explicit target (pin or `CREDO_DIR`) is always required, so a hub that is itself a credo project can never be silently used for another repo's work. A commented `# hub:` does not count.
- **Session pin**: new `/credo:project` command + `hooks/session-project-set.sh` (mirrors `session-mode-set.sh`; session_id from `$CREDO_SESSION_ID` > `$CLAUDE_CODE_SESSION_ID`, stored under `${CREDO_SESSION_PROJECTS_DIR:-$HOME/.claude/credo/session-projects}/<id>`). No-arg shows the resolved target + hub state; with a path it pins the active repo for the session.
- **Guided setup**: `setup.md` handles the guard with an AskUserQuestion flow (use this dir / point at another repo / mark this dir as a hub) and writes `hub: true` for the user on confirmation - no hand-editing of config.
- **Reporting + docs**: `check-setup.sh` reports the resolved project dir + `cwd_is_hub`; `config.default.yaml` documents the `hub` field (commented, not set); `docs/credo-guide.md` gains a resolution-chain / hub / `/credo:project` section.
- Version 0.20.0.

## Test plan

- Resolver precedence verified in isolated dirs: CREDO_DIR wins; session pin returns the pinned `.credo`; existing non-hub `.credo` is used; `hub: true` -> exit 4 even with `.credo` present; commented `# hub:` is not a hub; no `.credo` -> exit 4
- credo-init: needs-target (exit 4) creates nothing; CREDO_DIR builds the full tree; a pin builds at the pinned repo, not the hub cwd; CREDO_TASK_BACKEND=gsd still gates out items
- session-project-set.sh: rejects empty/invalid session_id and a non-existent target path; writes atomically
- No regression on credo-config get/backend/paths/ensure-global; autonomy scripts and hooks.json untouched
- bash -n clean on all changed/new scripts; jq empty valid on plugin.json; both version files 0.20.0; no AI-trace characters in the diff; GENESIS.md untouched

## Notes

- Takes effect after updating the plugin to 0.20.0 and restarting Claude (the resolver runs at runtime).
- Non-blocking nits (optional, not fixed): `commands/project.md` uses a structured `arguments:` list while sibling commands use `arguments: none` (cosmetic); a greenfield repo now hits one guard question before `.credo/` is created (intended fail-safe tradeoff).
- Wiki (Credo page) updated to match - staged locally, pushed separately.
