### PR TITLE
v0.22.0: budget guardrails, weekly pause+resume, opt-in machine sleep

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -94,7 +94,7 @@ credo targets the repo you point it at (hub-aware): when your shell cwd is a lau
 
 ### Topic: Budget and Autonomy
 
-credo is limit-aware. In autonomous mode it reads the 5-hour and weekly usage caps (via the `limit` plugin cache), sizes tasks to fit the remaining budget, and pauses or hands off before a wall is hit. Approved GO items are worked unattended with keep-alive; each task and question fires an ntfy push so you can step away and still be called back.
+credo is limit-aware. In autonomous mode it reads the 5-hour and weekly usage caps (via the `limit` plugin cache), sizes tasks to fit the remaining budget, and pauses or hands off before a wall is hit. Approved GO items are worked unattended with keep-alive; each task and question fires an ntfy push so you can step away and still be called back. Autonomous machine power-down (sleep) is opt-in (default off, server-safe): the mode (StandBy / suspend or Ruhezustand / hibernate) and the exact command are chosen per platform at `/credo:setup`. ntfy is used only if you configured a topic.
 
 ### Topic: Verify and Safety
 

--- a/plugins/credo/commands/setup.md
+++ b/plugins/credo/commands/setup.md
@@ -291,6 +291,114 @@ Would you like to create a GSD project roadmap?
 
 If user chooses "Yes": Run `/gsd:create-roadmap` via Skill tool.
 
+## Step 8: Autonomy Preferences (Optional)
+
+These two preferences are personal / machine-level, so they belong in the GLOBAL credo
+config (all repos inherit them), NOT the project `.credo/config`. Get or create the global
+config path, then Read + Edit that file to set the keys directly (same approach as the
+`task_backend` write in Step 6 - do NOT shell out to a setter):
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" ensure-global
+```
+
+That prints (and creates if missing) the global config path. Only ask each question below if
+it was not already chosen - but detect "already chosen" from the GLOBAL config FILE itself
+(the ensure-global path), NOT from `credo-config.sh get`:
+
+- Sleep (machine power-down): to decide whether it was already chosen, check the GLOBAL
+  config file itself (the ensure-global path) for a top-level `sleep:` block (e.g. grep the
+  file for a `sleep:` line). Do NOT use `credo-config.sh get sleep.enabled` for this decision -
+  it returns the builtin template default `false` via the config cascade even when the global
+  file never set it, so it would wrongly look "already configured" and skip the question on
+  first-ever setup. Ask the sleep question UNLESS the global file already contains a `sleep:`
+  block.
+- ntfy: check the same GLOBAL config file for a non-empty `personal.ntfy_topic:` value OR
+  `personal.ntfy_optout: true`. Skip the ntfy question if EITHER is present (a set topic means
+  configured; an opt-out means the user already declined). Otherwise ask.
+
+### (a) Machine power-down (sleep)
+
+The power-down command is OS-specific and the right MODE differs by platform, so this is a
+platform-aware flow. It writes `sleep.enabled`, `sleep.mode`, and `sleep.command` to the
+GLOBAL config (Read + Edit the ensure-global path; append or update the `sleep:` block, same
+approach as `task_backend`). Ask only if no `sleep:` block exists (per the detection above).
+
+Step 1 - first AskUserQuestion, may it power down THIS machine at all:
+
+```
+May autonomous work power down THIS machine when it finishes or hits the weekly cap?
+
+- No, never power down this machine (Recommended) - required for servers; autonomous runs just end cleanly
+- Yes, power it down when autonomous work is done - only for a personal machine
+```
+
+- "No" -> write the `sleep:` block with `enabled: false` (leave `mode` and `command` empty).
+  Done - skip the rest of part (a).
+- "Yes" -> continue to Step 2.
+
+Step 2 - detect the platform:
+
+- WSL: `grep -qiE "microsoft|wsl" /proc/version` succeeds.
+- else read `uname -s`: `Linux` -> native Linux, `Darwin` -> macOS.
+
+Step 3 - on native Linux only, check power-state availability before offering modes:
+
+- `grep -qw disk /sys/power/state` -> hibernate (suspend-to-disk) is available.
+- `grep -qw mem /sys/power/state` -> suspend (suspend-to-RAM) is available.
+
+If `disk` is absent, do NOT offer hibernate (it is unavailable, typically because swap is
+smaller than RAM) - steer to suspend and say why.
+
+Step 4 - second AskUserQuestion, which mode, with a PLATFORM-SPECIFIC recommendation and the
+concrete command shown. Per-platform command table:
+
+- WSL: recommended Hibernate (`shutdown.exe /h`); alternative StandBy
+  (`rundll32.exe powrprof.dll,SetSuspendState 0,1,0`).
+- native Linux: recommended StandBy (`systemctl suspend`); alternative Ruhezustand / hibernate
+  (`systemctl hibernate`) - offer the hibernate alternative ONLY if `/sys/power/state` had
+  `disk`.
+- macOS: StandBy (`pmset sleepnow`) - single reasonable option.
+
+Present it like this, adapted to the detected platform (drop the hibernate row where it is
+unavailable, and mark the Recommended one per platform):
+
+```
+Which power-down mode? (detected platform: <WSL|Linux|macOS>)
+
+- StandBy (suspend) - <command> (Recommended on Linux) - low power, reliable, fast resume
+- Ruhezustand (hibernate) - <command> (Recommended on WSL) - writes RAM to disk, zero power
+```
+
+The shown command is a PROPOSAL the user can accept or override with their own command string
+(some machines differ). If the user gives a custom command, take it verbatim.
+
+Step 5 - write to the GLOBAL config: `sleep.enabled: true`, `sleep.mode: suspend` or
+`hibernate` (matching the chosen mode), and `sleep.command:` set to the chosen or custom
+command. Read + Edit the YAML directly (append or update the `sleep:` block).
+
+### (b) ntfy push notifications
+
+Use AskUserQuestion:
+
+```
+credo can send push notifications (via ntfy) so you get called back to the PC during autonomous work. Set it up?
+
+- Yes, I have an ntfy topic - I will paste my topic string
+- No, skip notifications - autonomous work runs without push (silent)
+```
+
+- "Yes" -> ask for the topic string, then write it to `personal.ntfy_topic` in the GLOBAL
+  config AND set `personal.ntfy_optout: false` (Read + Edit both values).
+- "No" -> leave `personal.ntfy_topic` empty and set `personal.ntfy_optout: true` in the GLOBAL
+  config (this explicit opt-out marker is what stops setup re-asking on every future run -
+  symmetric with the `sleep:` block). Note in the setup output that autonomous work will then
+  run without push notifications (silent) - this is fine and purely informational.
+
+ntfy is decided HERE at setup only. `personal.ntfy_optout` governs ONLY whether setup re-asks;
+it adds NO runtime prompt. At autonomous RUNTIME credo does NOT ask about ntfy: if a topic is
+set it is used, if empty it is silently skipped. Do not imply a runtime prompt.
+
 ## Setup Complete
 
 **If all steps were skipped (project.state was ready):**

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.21.0
+version: 0.22.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/scripts/credo-config.sh
+++ b/plugins/credo/scripts/credo-config.sh
@@ -314,15 +314,20 @@ for part in key.split("."):
     else:
         sys.exit(3)
 
+def _emit(x):
+    if x is None:
+        return ""
+    if isinstance(x, bool):
+        return "true" if x else "false"
+    return x
+
 if isinstance(node, (dict,)) or (isinstance(node, list) and any(isinstance(x, (dict, list)) for x in node)):
     print(json.dumps(node, ensure_ascii=False))
 elif isinstance(node, list):
     for x in node:
-        print("" if x is None else x)
-elif node is None:
-    print("")
+        print(_emit(x))
 else:
-    print(node)
+    print(_emit(node))
 PY
         ;;
     resolve-project)

--- a/plugins/credo/skills/budget/SKILL.md
+++ b/plugins/credo/skills/budget/SKILL.md
@@ -36,9 +36,19 @@ percent" are unrelated facts with unrelated responses.
 
 ## Data source: the limit-plugin cache only (B8)
 
-The limit plugin is a PREREQUISITE for all budget data. If it is absent, budget features
-are silently unavailable - do not error, just note that budget data cannot be read and
-fall back to the fail-safe caps below.
+The limit plugin is a PREREQUISITE for all budget data. Without a fresh cache, NO
+percentage-based cap is measurable or enforceable - not the schedule caps and not the
+fail-safe caps below, because every one of them is a percentage of a number that only the
+cache provides. Do not treat the fail-safe caps as a substitute; they too are unenforceable
+with no fresh cache. The only guardrail enforceable without the cache is a wall-clock
+timebox.
+
+- For non-autonomous, ad-hoc reads ("how much budget is left"): budget data is simply
+  unavailable - note that it cannot be read, do not error.
+- For AUTONOMOUS mode entry: never run blind and never silently ignore budgets. The
+  guardrail-availability gate in the credo `session-autonomous` skill decides what to do -
+  it asks the user (install the limit plugin, run a wall-clock timebox, or proceed at an
+  explicitly accepted risk). See that skill; this skill only supplies the honesty rationale.
 
 Two ways to read the current numbers:
 
@@ -172,10 +182,49 @@ There is no fixed percent of overshoot beyond the ceiling; do not plan to exceed
 ## Weekly ceiling and hibernate (B4)
 
 When the weekly axis reaches 99 percent (`seven_day.utilization >= 99`), move to rest /
-hibernate as soon as possible. The absolute weekly fail-safe is also 99 (below). The
-hibernate mechanics (veto window, double-hibernate protection, the "never auto-hibernate
-unless autonomous" rule) live in the autonomous session skill; this skill only sets the
-weekly trigger.
+hibernate as soon as possible. This 99 hibernate is the absolute LAST-RESORT net (it equals
+the absolute weekly fail-safe below); it always still triggers if the pause path fails or
+weekly climbs to 99. The hibernate mechanics (veto window, double-hibernate protection, the
+"never auto-hibernate unless autonomous" rule) live in the autonomous session skill; this
+skill only sets the weekly triggers - both the pause path here and the 99 net.
+
+### Weekly pause-and-resume - the PREFERRED path before the net (autonomous mode)
+
+The weekly reset is NOT a default showstopper. In autonomous mode, before falling to the 99
+net, prefer to pause the session across the weekly reset and then resume with a fresh weekly
+budget. Gate the whole path on `budget.weekly_pause.enabled` (default true); when false, only
+the 99 hibernate net applies.
+
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" get budget.weekly_pause.enabled
+"${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" get budget.weekly_pause.switch_percent
+```
+
+Read `seven_day_utilization` and `seven_day_resets_at` from the limit cache
+(`credo-budget-read.sh` - those are the exact keys it prints). "Reset is near" =
+`seven_day_resets_at` falls on the SAME local
+calendar day as now - read this dynamically from the cache, NEVER a hardcoded weekday (the
+reset day can change).
+
+- Weekly utilization below `switch_percent` (default 97): work normally under the
+  schedule's `weekly_cap`. No pause.
+- Weekly utilization at or above `switch_percent` AND the reset is near: do NOT hibernate.
+  Secure current work first (commit/push per the git-push policy), stop taking new large
+  chunks, then CHAIN ScheduleWakeup until just after `seven_day_resets_at` (use the wake
+  offset `wakeup.reset_offset_minutes`, fallback `wakeup.fallback_offset_minutes`; a single
+  ScheduleWakeup delay is clamped to at most one hour, so CHAIN for the longer wait). After
+  the reset, resume with the fresh weekly budget.
+- Weekly utilization at or above `switch_percent` but the reset is NOT near (a different
+  calendar day): the pause would mean sleeping too long - fall through to the normal
+  hibernate-at-99 path (the last-resort net).
+
+Reserve rule: never burn to 100 percent (the hard API wall). The ~97 switch point must leave
+room for the wake-chain itself (chained wakes cost budget) and a clean resume; that is why
+the switch fires below 99.
+
+The absolute weekly fail-safe (`budget_failsafe.weekly_percent`, default 99) always still
+triggers hibernate as the final net. The hibernate ACTION itself lives in the autonomous
+session skill; this skill only sets the weekly triggers (both the pause path and the 99 net).
 
 ## Wake-up after a reset (B7)
 
@@ -253,6 +302,9 @@ Rules for this gate:
 - `budget.five_hour.soft_percent` / `budget.five_hour.hard_percent` - off-hours 5h band.
 - `budget.nine_oclock_guard_reserve_percent` - reserve that must remain at 09:00.
 - `budget.task_sizing.large_below_percent` / `budget.task_sizing.medium_below_percent`.
+- `budget.weekly_pause.enabled` - gate for the weekly pause-and-resume path (default true).
+- `budget.weekly_pause.switch_percent` - weekly percent at which, if the reset is near, the
+  session pauses across the reset instead of hibernating (default 97).
 - `budget_failsafe.five_hour_percent` / `budget_failsafe.weekly_percent` - absolute caps.
 - `wakeup.reset_offset_minutes` / `wakeup.fallback_offset_minutes`.
 - `personal.commit_identity_hint` - optional identity cross-check.

--- a/plugins/credo/skills/session-autonomous/SKILL.md
+++ b/plugins/credo/skills/session-autonomous/SKILL.md
@@ -79,6 +79,24 @@ autonomously.
 
 ### Budget caps are always on
 
+Guardrail-availability gate (autonomy never runs without budgets/limits). At autonomous-mode
+entry, and before any autonomous start, check budget-data availability via the read-only
+`"${CLAUDE_PLUGIN_ROOT}/scripts/credo-budget-read.sh"`:
+
+- Exit 0 (fresh data): percentage caps are measurable and MANDATORY - proceed as today.
+- Exit 3 or 4 (no cache / stale cache): percentage caps CANNOT be enforced (credo `budget`
+  skill, B8 - the fail-safe caps are percentages too, so they are equally unenforceable).
+  Do NOT run blind and do NOT silently ignore budgets. Use AskUserQuestion with three
+  options:
+  a. Install the `limit` plugin for real budget safety, then re-check availability.
+  b. Run with a wall-clock timebox (max X hours / until a clock time) - the only guardrail
+     enforceable without the cache. Record the deadline and self-enforce it: end the run via
+     `credo-autonomy-off.sh` when the clock reaches it.
+  c. Proceed without budget guardrails - an explicit, user-accepted risk.
+
+This gate is what makes "autonomy never runs without budgets/limits" true. Send the
+come-to-PC ntfy before the AskUserQuestion (per the ntfy hybrid).
+
 Budget enforcement is unconditional in autonomous mode. Apply the credo `budget` skill in
 full: the daily cap schedule, the critical 09:00 guard, the 5-hour guard (skill behavior,
 check frequently including while subagents run, stop subagents with TaskStop before the
@@ -152,19 +170,54 @@ the subagent returns `{status: needs_decision, question}`, the main agent obtain
 (user, verbatim log, or documented default) and passes it back via SendMessage so the
 subagent continues with full context.
 
-### Hibernate at the end (I9)
+### Power down the machine at the end (I9)
 
-The global "never auto-hibernate" rule lives HERE now, scoped by mode:
+The machine power-down can be EITHER suspend (standby / suspend-to-RAM) OR hibernate
+(suspend-to-disk), per `sleep.mode`; refer to it generically as "power down / sleep the
+machine". The global "never auto power-down" rule lives HERE now, scoped by mode:
 
-- Non-autonomous modes (active, passive): NEVER auto-hibernate. Only hibernate on an
+- Non-autonomous modes (active, passive): NEVER auto power-down. Only sleep the machine on an
   explicit user request.
-- Autonomous mode: hibernate when EITHER everything is done, OR a showstopper occurs, OR
-  the weekly axis reaches 99 percent (that weekly trigger is set by the credo `budget`
-  skill; this skill owns the hibernate action).
+- Autonomous mode: the end-of-run triggers are EITHER everything is done, OR a showstopper
+  occurs, OR the weekly axis hits its power-down trigger. On the weekly axis the reset is NOT
+  a default showstopper: first PREFER the credo `budget` skill's weekly pause-and-resume
+  (when the reset is near - same local calendar day - and weekly is at or above
+  `switch_percent`, pause via chained ScheduleWakeup across the reset and resume with a fresh
+  weekly budget). Only the weekly last-resort net (99 percent) or a pause path that does not
+  apply (the reset is on a different calendar day) reaches an end-of-run trigger on the
+  weekly axis. The weekly triggers are set by the credo `budget` skill; this skill owns what
+  happens on a trigger - and whether that powers down the machine is gated below.
 
-Hibernate procedure (with protection against a spurious or double hibernate):
+Power-down is OFF by default - it must be opted into (server-safe). Whether an end-of-run
+trigger sleeps the machine is gated on `sleep.enabled`:
 
-1. Send an ntfy `high` announcing the pending hibernate and open a veto window -
+```
+"${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" get sleep.enabled
+"${CLAUDE_PLUGIN_ROOT}/scripts/credo-config.sh" get sleep.command
+```
+
+- `sleep.enabled` false (the DEFAULT): NEVER power down the machine. This is what keeps a
+  SERVER running autonomous work from being powered down unexpectedly. On every end-of-run
+  trigger (all done / showstopper / weekly cap reached) do NOT sleep - instead end the
+  autonomous run CLEANLY via `credo-autonomy-off.sh` and send a `high` ntfy stating why (run
+  complete, showstopper, or weekly cap reached). The machine stays on.
+- `sleep.enabled` true (opt-in, personal machine only): run the power-down procedure below
+  (veto window, double-fire protection, secure-work-first, then run the EXACT command from
+  `sleep.command`) on those same end-of-run triggers.
+- MISCONFIG guard: if `sleep.enabled` is true but `sleep.command` is EMPTY, that is a
+  misconfiguration. Do NOT guess or hardcode a command. End the run cleanly via
+  `credo-autonomy-off.sh` and send a `high` ntfy warning that sleep is enabled but no command
+  is configured (re-run `/credo:setup`). Never sleep the machine on a guessed command.
+
+Default OFF means autonomous work never powers down the machine unless the user opted in at
+setup (`/credo:setup`). The weekly pause-and-resume path (budget skill) is unaffected either
+way - it never powers down anyway; this gate governs only the last-resort 99 net and the
+end-of-run / showstopper power-down.
+
+Power-down procedure (only when `sleep.enabled` is true AND `sleep.command` is non-empty;
+with protection against a spurious or double power-down):
+
+1. Send an ntfy `high` announcing the pending power-down and open a veto window -
    `windows.veto_minutes` (default 20):
 
    ```
@@ -172,15 +225,17 @@ Hibernate procedure (with protection against a spurious or double hibernate):
    ```
 
 2. During the veto window, watch for the user coming back. If the user responds or
-   otherwise signals presence, CANCEL the hibernate - do not sleep the machine out from
+   otherwise signals presence, CANCEL the power-down - do not sleep the machine out from
    under an active user.
-3. Double-hibernate protection: record a timestamp / flag when a hibernate is initiated and
+3. Double-fire protection: record a timestamp / flag when a power-down is initiated and
    check it (plus whether the user is back) before issuing another, so a repeated trigger
-   cannot fire hibernate twice.
-4. Before hibernating, make sure work is secured (git-push policy and, where relevant, the
+   cannot fire the power-down twice.
+4. Before powering down, make sure work is secured (git-push policy and, where relevant, the
    credo `compact-plus` securing) so nothing is lost across the sleep.
+5. Run the EXACT command from `sleep.command` (read via the config above) to power down. Do
+   NOT hardcode or guess the command - it is platform- and mode-specific and set at setup.
 
-Never hibernate on your own initiative outside these autonomous triggers.
+Never power down the machine on your own initiative outside these autonomous triggers.
 
 ### Authority order when the user is away
 

--- a/plugins/credo/skills/wsl-env/SKILL.md
+++ b/plugins/credo/skills/wsl-env/SKILL.md
@@ -95,7 +95,7 @@ address is a private LAN address. Do not assume any particular subnet - what is 
 LAN range on one machine is not on another. Confirm the choice by reachability, then
 offer to store it in config so it need not be rediscovered.
 
-## Windows processes, launchers, logs, hibernate: use powershell.exe
+## Windows processes, launchers, logs, power-down: use powershell.exe
 
 Anything on the Windows side is driven through `powershell.exe`, which runs in the
 Windows context and can see Windows localhost, processes, and scripts:
@@ -108,9 +108,12 @@ Windows context and can see Windows localhost, processes, and scripts:
 - Stop a Windows-side process: `powershell.exe -NoProfile -Command "Stop-Process -Id <pid>"`
   or the project's stop script.
 - Read Windows logs by having `powershell.exe` read them on the Windows side.
-- Hibernate: `shutdown.exe /h` (subject to the credo autonomous-session hibernate rules -
-  veto window and double-hibernate protection; never hibernate on the agent's own
-  initiative outside those rules).
+- Machine power-down on the Windows side runs through `powershell.exe` too, but the ACTUAL
+  autonomous power-down command credo runs is NOT hardcoded here - it comes from the credo
+  `sleep.command` config (set at `/credo:setup`; on WSL that is typically `shutdown.exe /h`).
+  It is governed by the credo autonomous-session sleep rules (veto window and double-fire
+  protection; never on the agent's own initiative outside those rules). `sleep.command` is the
+  source of truth.
 
 If a Windows-side service must accept inbound connections from WSL and still cannot be
 reached after both methods above, a Windows Firewall inbound rule for that port may be

--- a/plugins/credo/templates/config.default.yaml
+++ b/plugins/credo/templates/config.default.yaml
@@ -64,6 +64,23 @@ wakeup:
   # Fallback delay (minutes) if the preferred offset cannot be used.
   fallback_offset_minutes: 1
 
+# --- sleep (autonomous end-of-run / weekly-cap machine power-down) ------------
+# Default OFF for safety: a server running autonomous work must NEVER be powered
+# down unexpectedly. Enable only on a personal machine you want powered down when
+# autonomous work finishes or hits the weekly cap. Opt in via /credo:setup, which
+# detects the platform and stores the exact command.
+#   mode:    "suspend" (standby / suspend-to-RAM) or "hibernate" (suspend-to-disk).
+#            On native Linux, hibernate is often unavailable (needs swap >= RAM) -
+#            suspend is the reliable default there; on WSL, hibernate (shutdown.exe /h)
+#            is the norm. Empty until chosen at setup.
+#   command: the exact shell command run to power down. Filled at setup; empty means
+#            not configured (an enabled-but-empty command is a misconfig - the run then
+#            ends cleanly WITHOUT powering down, never a guessed command).
+sleep:
+  enabled: false
+  mode: ""
+  command: ""
+
 # --- budget (consumed by the budget skill, Phase 5) --------------------------
 # Universal default cap schedule. Values are percent. Off-hours five_hour_cap
 # uses the soft/hard band (soft warn, hard stop); work-hours (Mon-Fri 09-17)
@@ -82,6 +99,15 @@ budget:
   task_sizing:
     large_below_percent: 60
     medium_below_percent: 80
+  # Weekly reset handling in autonomous mode. When the weekly reset is NEAR
+  # (seven_day.resets_at falls on the same local calendar day - read dynamically
+  # from the limit cache, never hardcoded) and weekly usage reaches switch_percent,
+  # the agent pauses via chained wake-ups until the reset and then resumes with a
+  # fresh weekly budget, instead of hibernating. The 99% weekly fail-safe hibernate
+  # (budget_failsafe.weekly_percent) always remains the last-resort net.
+  weekly_pause:
+    enabled: true
+    switch_percent: 97
   # Cap schedule. five_hour_cap is the hard cap for that window; off-hours use
   # the soft/hard band above (95 hard). weekly_cap is the weekly ceiling.
   schedule:
@@ -149,6 +175,11 @@ budget_failsafe:
 personal:
   # ntfy topic for push notifications. Empty -> notifications are skipped.
   ntfy_topic: ""
+  # ntfy opt-out marker. Setup-only: distinguishes "user declined notifications"
+  # from "never asked" so /credo:setup stops re-asking. true -> setup skips the ntfy
+  # question. It does NOT add any runtime prompt (runtime still just skips ntfy
+  # silently when the topic is empty).
+  ntfy_optout: false
   # Expected commit-identity hint (optional). Empty (recommended when you use more than
   # one identity) -> rely on the repo's git-log history plus its local gitconfig. It MAY
   # be set here as a default identity, but it is then overridden per project (cascade:


### PR DESCRIPTION
## Summary

Three related autonomous-mode safety improvements, all skill/config-level. Builds on v0.21.0.

## Changes

- **Budget guardrails are unconditional (#19).** Autonomy never runs without enforceable budget limits. Budget percentages come only from the limit-plugin cache; without a fresh cache no percentage cap (schedule or fail-safe) is enforceable - only a wall-clock timebox is. At autonomous-mode entry the agent checks cache availability and, if it is absent or stale, asks the user (install the limit plugin, run a wall-clock timebox, or proceed at an explicitly accepted risk) instead of running blind. The budget skill's data-source section is corrected to state this honestly.
- **Weekly reset is pause-and-resume, not a showstopper (#20).** When the weekly cap is near and the reset falls on the same local calendar day, the agent pauses via chained wake-ups across the reset and resumes with a fresh weekly budget, instead of stopping. The 99 percent weekly hibernate stays only as the last-resort net; a reset on a different day falls through to it. Switch point and toggle are config-driven (`budget.weekly_pause.*`).
- **Machine power-down (sleep) is opt-in and default-off (server-safe).** A server running autonomous work is never powered down by default. Power-down is opt-in via `/credo:setup`, which detects the platform (WSL / native Linux / macOS), checks Linux `/sys/power/state` availability, and stores the mode and exact command (`sleep.enabled/mode/command`). WSL defaults to hibernate (`shutdown.exe /h`), native Linux to standby (`systemctl suspend`); the shown command is user-overridable. At runtime the exact stored command is used; an enabled-but-unconfigured command ends the run cleanly instead of guessing. The old hardcoded `shutdown.exe /h` reference in the wsl-env skill now points at `sleep.command` as the source of truth.
- **Housekeeping:** `credo-config.sh get` now emits canonical lowercase booleans (matching the `is-hub` subcommand); setup records an ntfy opt-out so it stops re-asking; cache-key notation unified to the keys the read helper actually prints.
- Version 0.22.0.

## Test plan

- Guardrail gate: with a fresh cache, caps mandatory; with no/stale cache, the entry asks rather than running unguarded
- Weekly pause: near-reset same-day pauses and resumes; different-day falls through to the 99 net; 99 fail-safe still triggers
- Sleep default-off: no path powers down the machine with default config; enabled runs the exact `sleep.command`; enabled-but-empty ends cleanly
- `credo-config.sh get` returns lowercase booleans; scalar strings, empty scalars, missing keys, and JSON containers unchanged; bash -n clean
- ntfy opt-out marker stops setup from re-asking; runtime still skips silently on empty topic
- No AI-trace glyphs; both version files 0.22.0; jq valid on plugin.json
