### PR TITLE
v0.23.0: harden audit/DoD gate (finding disposition + docs currency)

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -90,7 +90,7 @@ To onboard an existing repository into this structure, run `/credo:migrate` - it
 
 credo targets the repo you point it at (hub-aware): when your shell cwd is a launch hub rather than the repo you are working on, pin the real target with `/credo:project <path>` so the item tree and config resolve to the right place. A directory marked `hub: true` is never auto-targeted.
 
-**The Definition of Done is hard:** success criteria observably met, code wired in, an independent audit subagent (not the builder) passed it, UI work visually verified in a real browser with screenshot evidence, and docs updated in the same change. "The test passed" is not done.
+**The Definition of Done is hard:** success criteria observably met, code wired in, an independent audit subagent (not the builder) passed it, UI work visually verified in a real browser with screenshot evidence, and docs updated in the same change - including the project wiki, via `/dogma:docs-update` where dogma is installed (a best-effort manual update otherwise). "The test passed" is not done.
 
 ### Topic: Budget and Autonomy
 

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.22.0
+version: 0.23.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/skills/audit/SKILL.md
+++ b/plugins/credo/skills/audit/SKILL.md
@@ -63,7 +63,10 @@ For the item under review, gather the ground truth first (read, do not guess):
 Then compare the actual built result (files, wiring, tests, verify evidence) against
 that ground truth. Confirm each success criterion is genuinely met, that new code is
 reachable and wired (not present-but-unreachable), and that documentation was updated
-in the same change (stale docs = incomplete).
+in the same change (stale docs = incomplete). Docs currency includes the project wiki
+(a separate repo) and in-repo READMEs, not just files inside the commit; where dogma is
+present, check that `/dogma:docs-update` was the mechanism (or an equivalent manual
+update happened). audit checks and flags stale docs - it does not run the update itself.
 
 ## Severity levels
 
@@ -100,6 +103,47 @@ No evidence -> not a finding. A verdict without evidence is not acceptable.
   completion needs, it is part of this item, not a new one.
 - The auditor never silently downgrades or repairs; it proposes, the move follows the
   verdict.
+
+## Disposition of findings (nothing is silently dropped)
+
+EVERY finding - at every severity, MINOR and NIT included - must be explicitly
+DISPOSITIONED. Dropping a finding with no disposition is not allowed. The three allowed
+dispositions are:
+
+1. **Fixed now** - the finding is corrected at its root.
+2. **Deferred** - captured as a tracked item (see the credo items skill) with a recorded
+   reason for deferring.
+3. **Wontfix** - a conscious decision by the USER not to act (in autonomous mode, a
+   documented default stands in for the user's call).
+
+The severity levels and the evidence rule above are unchanged; this governs what happens
+to a finding AFTER it is reported, not whether it is reported.
+
+**Code fix beats a doc workaround.** When a finding can be fixed cleanly in code, fix it at
+the root rather than bloating the docs to describe or justify the messiness. Follow the
+language and project best practices and do not mix conventions - for example a config
+getter should emit canonical lowercase booleans rather than leaking Python-style
+`True`/`False` and then documenting the leak. A doc-only workaround is a fallback only when
+a clean code fix genuinely harms (a real, stated reason - e.g. it would break other
+callers) or is impossible. Convenience is not such a reason.
+
+**audit still only proposes.** audit is read-only: it names each finding and its
+recommended disposition, but it never edits, fixes, or commits. The disposition is carried
+out by the acting/building agent per the audit's proposal - that separation is the point of
+the gate.
+
+**How the acting agent acts on it, by session mode:**
+
+- **Presence modes (active, passive)** - the acting agent EXPLAINS each finding to the user
+  and recommends the fix via a question. Default recommendation: fix. The user may deem a
+  finding unimportant; borderline calls go to the user, never to the agent's own
+  convenience.
+- **Autonomous mode** - the acting agent fixes the findings inline BY DEFAULT without
+  asking (asking would block an unattended run), and records what was fixed in the item
+  and the digest. Where a clean fix is genuinely impossible or harmful (a real, stated
+  reason), or the finding is genuinely independent of the audited item's core, it records
+  a documented wontfix (the documented default standing in for the user) or defers it as a
+  tracked item with the reason - never blocking the unattended run to ask.
 
 ## Result: a decision proposal
 

--- a/plugins/credo/skills/items/SKILL.md
+++ b/plugins/credo/skills/items/SKILL.md
@@ -152,8 +152,14 @@ An item may move into `2_done/` ONLY when ALL of these hold. This gate is hard.
    passive, autonomous), no exceptions. Only a passing audit lets the item enter
    `2_done/`.
 5. **Docs updated in the same change** - documentation is part of the change, not a
-   follow-up. Stale docs = incomplete (C14). Search `docs/**` and `.credo/docs/` for what
-   the change affects and update it now.
+   follow-up. Any change that affects documented behavior MUST update the docs in the same
+   change; stale docs = incomplete (C14). Prefer `/dogma:docs-update` when dogma is
+   installed - it is the canonical README + wiki sync; if dogma is not installed, do a
+   best-effort manual update of the affected docs (companion tool when present, graceful
+   degrade when not). Scope explicitly includes the project wiki (a separate repo) and
+   in-repo READMEs, not just files inside this commit - "same change" is not "same repo
+   only". Search `docs/**`, `.credo/docs/`, in-repo READMEs, and the wiki for what the
+   change affects and update it now.
 6. **Version bump as part of the DoD** - bump the version as part of completing the work,
    dogma-first (follow dogma's versioning if present), credo as fallback only.
 

--- a/plugins/credo/skills/verify/SKILL.md
+++ b/plugins/credo/skills/verify/SKILL.md
@@ -101,3 +101,8 @@ layout, real interaction, live update where required, hard reload after rebuild,
 saved screenshots - is mandatory before the item may move to done. If verification
 surfaces a defect, the item is not done: it goes back to clarification with a note on
 what was missed, per the credo item model. Never downgrade or self-approve this gate.
+
+Visual proof is not the whole DoD: the same change must also carry its docs currency -
+including the project wiki (a separate repo), via `/dogma:docs-update` where dogma is
+installed or a best-effort manual update otherwise. The credo items skill owns that
+requirement; this gate does not restate it.


### PR DESCRIPTION
## Summary

Hardens credo's audit / Definition-of-Done gate in two related ways, so quality findings and documentation currency actually bite. Skill/docs-level only.

## Changes

- **Finding disposition (audit skill).** Every audit finding - at every severity, MINOR and NIT included - must be explicitly dispositioned: fixed now, deferred as a tracked item with a recorded reason, or a conscious wontfix (in autonomous mode, a documented default). Silently dropping a finding is no longer allowed. A clean code fix takes priority over a documentation workaround; a doc-only workaround is a fallback only when a code fix genuinely harms (a real stated reason) or is impossible. audit stays read-only - it proposes the disposition, the acting agent carries it out. Mode-aware acting: presence modes explain each finding and recommend the fix; autonomous mode fixes inline by default without asking (deferring or recording a documented wontfix where a clean fix is impossible/harmful or the finding is independent).
- **Docs currency (items / verify / psalm DoD).** The "docs updated in the same change" clause is now concrete and tool-aware: prefer `/dogma:docs-update` when dogma is installed (canonical README + wiki sync), else a best-effort manual update. Scope explicitly includes the project wiki (a separate repo) and in-repo READMEs - "same change" is not "same repo only". The audit gate checks docs currency incl. the wiki (it flags stale docs; it does not run the update).
- Version 0.23.0.

## Test plan

- audit report lists a disposition for every finding incl. NIT; a dropped finding is a gate failure
- Presence mode explains + recommends; autonomous mode fixes inline and records, deferring only with a stated reason
- items DoD gate requires docs updated in the same change, wiki included, via dogma:docs-update where available
- No AI-trace glyphs; both version files 0.23.0; jq valid on plugin.json
