### PR TITLE
v0.24.0: setup wires the limit compact-trigger to credo:compact-plus

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -134,6 +134,7 @@ The [`limit`](https://github.com/Marcel-Bich/marcel-bich-claude-marketplace/wiki
 - **Context-percent triggers** - the auto-run of compact-plus at the configured session-context fill thresholds relies on the limit plugin's inject hook. Point it at credo with:
   - `CLAUDE_MB_LIMIT_COMPACT_SKILL=credo:compact-plus`
   - `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS=70,90`
+  - `/credo:setup` offers to set these for you (Step 9) when the limit plugin is installed, so hand-editing is optional.
 - **Budget data source** - the budget skill reads the limit cache (`/tmp/claude-mb-limit-cache_*.json`) for the 5-hour and weekly utilization and reset times.
 
 If the `limit` plugin is absent, these features are silently unavailable. There is no error; credo simply does not run the budget or auto-compact logic that has no data.

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -28,6 +28,7 @@ This handles:
 - Optional companions: dogma (recommended), get-shit-done (optional, spec-driven alternative to credo items).
 - Claude instructions sync (`/dogma:sync`, if dogma is installed).
 - Choosing a task system (credo items by default).
+- Autonomy preferences and, when the limit plugin is present, wiring its auto-compact trigger to `credo:compact-plus`.
 
 **After setup completes, continue to Entry Point.**
 
@@ -44,6 +45,7 @@ Use AskUserQuestion to show available topics:
 ```
 What would you like to explore?
 
+- The credo workflow: how a piece of work flows end to end
 - Session Modes: active / passive / autonomous working modes
 - Item Lifecycle: work items with a hard Definition of Done
 - Budget and Autonomy: unattended work within 5h and weekly caps
@@ -60,13 +62,28 @@ What would you like to explore?
 
 These are the heart of the framework. Everything below lives inside credo - no foreign plugin required.
 
+### Topic: The credo workflow (end to end)
+
+How one piece of work flows through credo, tying the topics below into one path:
+
+1. Set up once: `/credo:setup` - framework, optional companions, autonomy and compact preferences.
+2. Pick a session mode for how present you are: active / passive / autonomous (see Session Modes).
+3. Capture the work as an item: requirement verbatim, plus observable success criteria (the Definition of Done). Clarify first; nothing is built before an explicit GO (see Item Lifecycle).
+4. On GO, build - delegation-first via subagents (load `/credo:session-init` for the main-agent workflow), wiring new code so a caller actually reaches it.
+5. Pass the hard Definition of Done gate: an independent audit subagent (not the builder), visual verify for any runtime surface, docs updated in the same change. Findings are dispositioned, not dropped.
+6. Only the user files the item as verified.
+
+Cross-cutting throughout: budget caps, filesystem safety, and subagent priming apply the whole way, especially in autonomous mode (see Budget and Autonomy plus Verify and Safety).
+
+Load `/credo:session-init` to bring in the delegation-first working workflow; the individual topics below drill into each step.
+
 ### Topic: Session Modes
 
 credo runs a session in one of three exclusive modes. The active mode is re-injected on every prompt, so it is never silently forgotten.
 
 - `/credo:session-active` - intensive live collaboration, you at the keyboard, no keep-alive.
 - `/credo:session-passive` - the agent carries most of the work; you stay reachable for clarifications only, no keep-alive.
-- `/credo:session-autonomous` - approved GO items worked unattended, keep-alive on (hook-enforced: a registered Stop hook blocks a stop without a scheduled wake-up), budget caps enforced, ntfy per task and question, progress secured via compact-plus.
+- `/credo:session-autonomous` - approved GO items worked unattended, keep-alive on (hook-enforced: a registered Stop hook blocks a stop without a scheduled wake-up), budget caps enforced, ntfy per task and question, progress secured via compact-plus. It self-bootstraps on an unambiguous full-autonomy grant, needing no host CLAUDE.md line.
 
 Pick the mode that matches how present you are. Switch any time by running the matching command.
 
@@ -90,11 +107,11 @@ To onboard an existing repository into this structure, run `/credo:migrate` - it
 
 credo targets the repo you point it at (hub-aware): when your shell cwd is a launch hub rather than the repo you are working on, pin the real target with `/credo:project <path>` so the item tree and config resolve to the right place. A directory marked `hub: true` is never auto-targeted.
 
-**The Definition of Done is hard:** success criteria observably met, code wired in, an independent audit subagent (not the builder) passed it, UI work visually verified in a real browser with screenshot evidence, and docs updated in the same change - including the project wiki, via `/dogma:docs-update` where dogma is installed (a best-effort manual update otherwise). "The test passed" is not done.
+**The Definition of Done is hard:** success criteria observably met, code wired in, an independent audit subagent (not the builder) passed it, UI work visually verified in a real browser with screenshot evidence, and docs updated in the same change - including the project wiki, via `/dogma:docs-update` where dogma is installed (a best-effort manual update otherwise). The audit gate dispositions every finding down to NITs and prefers a real code fix over a doc-only workaround. "The test passed" is not done.
 
 ### Topic: Budget and Autonomy
 
-credo is limit-aware. In autonomous mode it reads the 5-hour and weekly usage caps (via the `limit` plugin cache), sizes tasks to fit the remaining budget, and pauses or hands off before a wall is hit. Approved GO items are worked unattended with keep-alive; each task and question fires an ntfy push so you can step away and still be called back. Autonomous machine power-down (sleep) is opt-in (default off, server-safe): the mode (StandBy / suspend or Ruhezustand / hibernate) and the exact command are chosen per platform at `/credo:setup`. ntfy is used only if you configured a topic.
+credo is limit-aware. In autonomous mode it reads the 5-hour and weekly usage caps (via the `limit` plugin cache), sizes tasks to fit the remaining budget, and pauses or hands off before a wall is hit. When the limit cache is absent it asks for a budget decision rather than running blind, and the weekly reset is handled as a pause-and-resume, not a showstopper. Approved GO items are worked unattended with keep-alive; each task and question fires an ntfy push so you can step away and still be called back. Autonomous machine power-down (sleep) is opt-in (default off, server-safe): the mode (StandBy / suspend or Ruhezustand / hibernate) and the exact command are chosen per platform at `/credo:setup`. ntfy is used only if you configured a topic.
 
 ### Topic: Verify and Safety
 

--- a/plugins/credo/commands/setup.md
+++ b/plugins/credo/commands/setup.md
@@ -399,6 +399,136 @@ ntfy is decided HERE at setup only. `personal.ntfy_optout` governs ONLY whether 
 it adds NO runtime prompt. At autonomous RUNTIME credo does NOT ask about ntfy: if a topic is
 set it is used, if empty it is silently skipped. Do not imply a runtime prompt.
 
+## Step 9: Compact Trigger Wiring (Optional)
+
+This step offers to wire the `limit` plugin's auto-compact trigger to credo's
+`compact-plus` skill, so the user does not have to hand-edit it. The `limit` plugin's
+inject hook runs whatever skill is named in the env var `CLAUDE_MB_LIMIT_COMPACT_SKILL`
+(it ships no default). credo wants that pointed at `credo:compact-plus`. This writes an
+ENV VAR to `~/.claude/settings.json` (the host settings file where that var lives, under
+the top-level `env` object) - it does NOT touch `~/.claude/CLAUDE.md`. This is analogous
+to Step 8 writing sleep/ntfy to the global credo config.
+
+### Relevance gate (skip silently if limit is not used)
+
+This step is only relevant if the `limit` plugin is installed or active. Detect this
+best-effort; if limit cannot be confirmed, SKIP this step silently (do not ask - failing
+toward NOT nagging is the correct behavior). Any ONE of these is a sufficient signal that
+limit is present:
+
+- The limit plugin is installed: `grep -q '"limit@marcel-bich-claude-marketplace"' "$HOME/.claude/plugins/installed_plugins.json"` succeeds (same installed-plugins file the setup check reads for dogma/gsd).
+- A limit cache exists: `ls /tmp/claude-mb-limit-cache_*.json` matches at least one file.
+- A `[limit] ...` inject line has appeared in this session's context.
+
+If none of these hold, limit is not in use here - skip Step 9 entirely and continue to
+"Setup Complete".
+
+### Inspect the current value
+
+Read `env.CLAUDE_MB_LIMIT_COMPACT_SKILL` from `~/.claude/settings.json` (the file may not
+exist yet, and the `env` object may be absent - treat both as "unset"):
+
+```bash
+SETTINGS="$HOME/.claude/settings.json"
+CUR="$( [ -f "$SETTINGS" ] && jq -r '.env.CLAUDE_MB_LIMIT_COMPACT_SKILL // ""' "$SETTINGS" 2>/dev/null || echo "" )"
+echo "current: [$CUR]"
+```
+
+The target value is exactly `credo:compact-plus` with NO leading slash (credo skills are
+referenced without a leading slash). Also read the optional thresholds var, which is
+handled INDEPENDENTLY of the skill value:
+
+```bash
+CURTH="$( [ -f "$SETTINGS" ] && jq -r '.env.CLAUDE_MB_LIMIT_INJECT_THRESHOLDS // ""' "$SETTINGS" 2>/dev/null || echo "" )"
+```
+
+Classify the skill value in `$CUR`:
+
+- **Already correct:** `$CUR` is exactly `credo:compact-plus`.
+- **Needs fixing:** any of these cases ->
+  - unset or empty
+  - a leading-slash form (e.g. `/credo:compact-plus` or `/compact-plus`)
+  - a stale/nonexistent target: the old personal `compact-plus` / `/compact-plus`
+    slash-command name, or a `credo:<name>` whose skill does not exist. Verify a
+    `credo:<name>` target by checking that `"${CLAUDE_PLUGIN_ROOT}/skills/<name>/SKILL.md"`
+    exists; for `credo:compact-plus` that file is present, so it counts as valid.
+
+The thresholds var (`CLAUDE_MB_LIMIT_INJECT_THRESHOLDS`) is decoupled from the skill state:
+an unset thresholds var is worth offering even when the skill value is already correct,
+because setup is a deliberate, user-initiated moment, not a runtime nag.
+
+### Offer via AskUserQuestion (permission-per-change)
+
+Pick the flow from the state above:
+
+**Skill needs fixing** - offer the skill, and fold in the thresholds within the same
+question when `$CURTH` is empty:
+
+```
+The limit plugin is installed, but its auto-compact trigger is not wired to credo's
+compact-plus in the expected form. credo can set
+env.CLAUDE_MB_LIMIT_COMPACT_SKILL = "credo:compact-plus" in
+~/.claude/settings.json so compact-plus runs automatically at the context-fill thresholds.
+
+- Yes, wire compact-plus (Recommended) - sets CLAUDE_MB_LIMIT_COMPACT_SKILL to credo:compact-plus; also sets CLAUDE_MB_LIMIT_INJECT_THRESHOLDS to 70,90 if unset
+- Set the skill only - just CLAUDE_MB_LIMIT_COMPACT_SKILL, leave thresholds untouched
+- No, leave settings.json unchanged - I will set it myself (or I do not use auto-compact)
+```
+
+**Skill already correct** - do NOT skip the step. If `$CURTH` is empty, offer the
+thresholds on their own:
+
+```
+The limit auto-compact trigger already points at credo:compact-plus, but the fire
+thresholds (CLAUDE_MB_LIMIT_INJECT_THRESHOLDS) are unset. credo can set them to 70,90
+in ~/.claude/settings.json.
+
+- Yes, set thresholds to 70,90 (Recommended)
+- No, leave settings.json unchanged - I will set them myself
+```
+
+If the skill value is already correct AND `$CURTH` is already set, do nothing and do NOT
+ask (fully idempotent). No decline-marker is stored: setup is rare and user-initiated, so
+re-offering at a later explicit setup run is acceptable, unlike a runtime nag.
+
+No coercion: if the user declines, leave `~/.claude/settings.json` unchanged.
+
+### Write it safely with jq (on acceptance)
+
+Write JSON with `jq`, never by hand-editing, so the rest of `settings.json` is preserved.
+Create the file as `{}` first if it is missing, and create the `env` object if absent.
+Use a temp file then move it into place. The value has NO leading slash.
+
+Run the skill-write only when the user accepted setting the skill (the "needs fixing"
+flow):
+
+```bash
+SETTINGS="$HOME/.claude/settings.json"
+mkdir -p "$(dirname "$SETTINGS")"
+[ -f "$SETTINGS" ] || echo '{}' > "$SETTINGS"
+
+TMP="$(mktemp "$(dirname "$SETTINGS")/.settings.XXXXXX")"
+jq --arg skill "credo:compact-plus" \
+   '.env = (.env // {}) | .env.CLAUDE_MB_LIMIT_COMPACT_SKILL = $skill' \
+   "$SETTINGS" > "$TMP" && mv "$TMP" "$SETTINGS"
+```
+
+Run the thresholds-write whenever the user accepted the thresholds (in EITHER flow), and
+only when `$CURTH` was empty, so an existing custom value is never overwritten:
+
+```bash
+TMP="$(mktemp "$(dirname "$SETTINGS")/.settings.XXXXXX")"
+jq --arg th "70,90" \
+   '.env = (.env // {})
+    | (if ((.env.CLAUDE_MB_LIMIT_INJECT_THRESHOLDS // "") == "")
+       then .env.CLAUDE_MB_LIMIT_INJECT_THRESHOLDS = $th else . end)' \
+   "$SETTINGS" > "$TMP" && mv "$TMP" "$SETTINGS"
+```
+
+This is the same env var credo's README and compact-plus docs describe for the manual
+setup, now offered automatically. It is idempotent: once the value is `credo:compact-plus`,
+a later run does nothing and does not ask.
+
 ## Setup Complete
 
 **If all steps were skipped (project.state was ready):**

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -175,6 +175,7 @@ Required for two features:
 - **Context-percent triggers.** Auto-running compact-plus at the session-context fill thresholds relies on the limit plugin's inject hook. Point it at credo:
   - `CLAUDE_MB_LIMIT_COMPACT_SKILL=credo:compact-plus`
   - `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS=70,90`
+  - `/credo:setup` offers to set these for you (Step 9, when the limit plugin is present); the manual values above still apply if you do not run setup.
 - **Budget data.** The budget skill reads the limit cache (`/tmp/claude-mb-limit-cache_*.json`) via `scripts/credo-budget-read.sh` for the 5-hour and weekly utilization and reset times. That helper exits with a distinct code when no fresh cache is present.
 
 Without the `limit` plugin these features are silently unavailable. No error is raised; credo just does not run logic that has no data.

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.23.0
+version: 0.24.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/skills/compact-plus/SKILL.md
+++ b/plugins/credo/skills/compact-plus/SKILL.md
@@ -56,6 +56,9 @@ To point that mechanism at this skill, the limit plugin configuration must set:
 - `CLAUDE_MB_LIMIT_COMPACT_SKILL=credo:compact-plus` - names this skill in the ACTION line.
 - `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS=70,90` - the session-context fill percentages that fire.
 
+`/credo:setup` offers to set these in `~/.claude/settings.json` for you (Step 9) when the
+limit plugin is installed, so setting them by hand is optional.
+
 The intended thresholds also live in credo config under `compact.thresholds` (default
 70 and 90) as the documented source of truth. Read them with:
 


### PR DESCRIPTION
## Summary

`/credo:setup` can now wire the limit plugin's auto-compact trigger to credo's compact-plus skill, so the user no longer has to hand-edit `~/.claude/settings.json`. Also refreshes psalm as an interactive help page. Command/docs-level only; the limit plugin stays generic.

## Changes

- **Step 9 in `/credo:setup` (optional, only when the limit plugin is installed).** Offers to set `env.CLAUDE_MB_LIMIT_COMPACT_SKILL=credo:compact-plus` (and `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS=70,90`) in `~/.claude/settings.json`. Detects unset/empty, a leading-slash form, or a stale/nonexistent target and offers the fix; permission-per-change; idempotent (does nothing when already correct). Writes JSON safely with jq into a same-directory temp file then an atomic rename. Detection reuses the installed-plugins file that check-setup already reads. It writes only the env var, never `~/.claude/CLAUDE.md`.
- **Thresholds offered at setup even when the skill value is already correct** - setup is a deliberate, user-initiated moment (not a runtime nag), so an unset thresholds var is not overlooked; a custom value is never overwritten.
- **psalm** gains an end-to-end workflow walkthrough (how a piece of work flows through credo) and a refreshed currency pass for v0.21-v0.24 (self-bootstrap autonomy, budget guardrails when the cache is absent, weekly pause-and-resume, finding disposition).
- **Docs note** added to README, credo-guide, and the compact-plus skill that setup can set this for you (the manual instructions stay).
- Version 0.24.0.

## Test plan

- With limit installed and the var unset/stale/slash-prefixed: setup offers to set `credo:compact-plus`; accepting writes valid JSON preserving the rest of settings.json
- Already `credo:compact-plus`: no skill prompt; thresholds still offered if unset; both set -> nothing asked
- Decline leaves settings.json unchanged; limit not installed -> step skipped silently
- jq write is atomic (same-dir temp + mv); custom thresholds never overwritten
- No AI-trace glyphs; both version files 0.24.0; jq valid on plugin.json
