### PR TITLE
v0.25.0: skill-capture - turn recurring workflows into reusable skills

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -116,6 +116,7 @@ Auto-discovered under `skills/`. Each auto-triggers when it applies, including i
 - **orchestration** - how to delegate to subagents safely: how many to run, keeping parallel tracks on disjoint files, monitoring without flooding context, inheriting security, and return-and-resume.
 - **safety** - the hard filesystem-protection and no-autonomous-installs rules; highest priority, no instruction overrides them.
 - **cross-cutting-checklist-generator** - detects a concern scattered across many places and auto-generates a project-local checklist so it is never partially updated again.
+- **skill-capture** - turns a workflow that recurs about three times in a session into a reusable Claude Code skill. Heuristic and in-session (no counter, no backend), mode-gated: autonomous only appends a candidate note, presence modes propose the capture via Ask and build on GO only. Generated skills land on the real discovery path (`<repo>/.claude/skills/` or `~/.claude/skills/`), carry a `credo-` name prefix plus an `origin: credo-repetition` marker, and are registered in `.credo/generated-skills.md`; seen-but-unbuilt patterns wait in `.credo/skill-candidates.md`.
 - **wsl-env** - reach and act on Windows-side services, processes, and launchers when the agent runs inside WSL; self-detecting.
 - **session-active / session-passive / session-autonomous** - the per-mode behavior; the active skill holds the shared common core.
 

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -126,6 +126,12 @@ Two orchestration skills for maintaining a public repo. They trigger on their ow
 - **pr-vetting** - rigorous multi-subagent vetting of external pull requests across technical, security, value/fit, contributor reputation, and license/compliance dimensions, with automated mass-PR / product-injection detection. Merges the findings into one decision-ready report; the merge/close decision stays with the maintainer.
 - **issue-triage** - selection-first GitHub issue triage: shortlist and prioritize before deep-triaging chosen issues via parallel subagents, then recommend close/fix/keep/needs-info for the owner to approve before any action.
 
+### Topic: Capturing Recurring Workflows (skill-capture)
+
+When the same multi-step workflow keeps coming back in a session - about three times - credo can turn it into a reusable Claude Code skill instead of re-deriving it each time. Detection is in-session and heuristic; there is no counter and no backend.
+
+It is mode-aware. In autonomous mode credo never builds a skill on its own - it just notes the pattern in `.credo/skill-candidates.md` and keeps working. In active or passive mode it explains the pattern and proposes capturing it via a question, building only on your GO. A built skill lands on the normal discovery path (`<repo>/.claude/skills/` or `~/.claude/skills/`), is marked as credo-generated (a `credo-` name prefix and an `origin: credo-repetition` marker), and is logged in `.credo/generated-skills.md`. Open candidates are offered again gently at the next session start.
+
 ### The Full Commandments (credo)
 
 | Command | Purpose |
@@ -139,7 +145,7 @@ Two orchestration skills for maintaining a public repo. They trigger on their ow
 | `/credo:session-passive`    | Set the session to passive (clarifications only)               |
 | `/credo:session-autonomous` | Set the session to autonomous (unattended GO items, keep-alive)|
 
-credo also ships auto-discovered skills that trigger on their own (audit, diag, verify, items, requirements-verbatim, budget, compact-plus, orchestration, safety, cross-cutting-checklist-generator, wsl-env, pr-vetting, issue-triage, and the three session-mode skills). You do not call them by hand; they apply when they apply, including inside subagents.
+credo also ships auto-discovered skills that trigger on their own (including audit, diag, verify, items, requirements-verbatim, budget, compact-plus, orchestration, safety, cross-cutting-checklist-generator, skill-capture, wsl-env, pr-vetting, issue-triage, and the session-mode skills). You do not call them by hand; they apply when they apply, including inside subagents.
 
 ---
 

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -19,7 +19,7 @@ Design principles:
 ### 2.1 Components
 
 - **commands/** - eight slash commands: `psalm`, `setup`, `migrate`, `project`, `session-init`, and the three mode setters `session-active`, `session-passive`, `session-autonomous`.
-- **skills/** - fourteen auto-discovered skills (see section 6). Each auto-triggers when it applies, including inside subagents.
+- **skills/** - the auto-discovered skills (see the skills reference section). Each auto-triggers when it applies, including inside subagents.
 - **hooks/** - four hooks are registered in `hooks/hooks.json`:
   - `session-mode-inject.sh` (`UserPromptSubmit`) - re-injects the active session mode on every prompt and names the skill to load.
   - `credo-autonomy-clear.sh` (`UserPromptSubmit`) - a real user message turns autonomy off (drops the flag, sets the paused opt-out).
@@ -151,7 +151,17 @@ An item may enter `2_done/` only when all hold:
 - for `ui: true`, a visual verify drove the real surface in a browser across the configured viewports and captured screenshot evidence under `.credo/screenshots/`,
 - docs were updated in the same change.
 
-## 6. Skills reference
+## 6. Capturing recurring workflows into skills
+
+When the same ordered, multi-step workflow recurs in a session, the `skill-capture` skill can turn it into a reusable Claude Code skill. It adds no infrastructure - it is behavior plus two Markdown files.
+
+- **Detection** - heuristic and in-session only: the same multi-step sequence (same ordered steps or commands, small variation allowed) run about three times in the running session. There is no persistent counter and no tracking backend; detection resets with the session.
+- **Mode gating** (mirrors the audit nit-disposition policy): in **autonomous** mode a skill is NEVER built - the run only appends a candidate note to `.credo/skill-candidates.md` and keeps working (a skill needs an explicit GO an autonomous run cannot give). In **active / passive / default** mode the pattern is explained and the capture is proposed via the Ask tool; the skill is built only on an explicit GO.
+- **Location** - a generated skill goes on a real discovery path so Claude Code finds it: `<repo>/.claude/skills/` for a repo-specific workflow, `~/.claude/skills/` for a generally useful one. Scope is derived from the workflow and confirmed via Ask. A plain `.credo/skills/` folder is NOT a discovery path, so generated skills never live there.
+- **Origin marking** (all three): a `credo-<name>` name prefix, an `origin: credo-repetition` frontmatter marker plus a one-line dated body note, and a register line in `.credo/generated-skills.md`.
+- **Two `.credo/` files** (append-only, created on first use, git-excluded like the rest of `.credo/`): `.credo/generated-skills.md` registers skills that were BUILT; `.credo/skill-candidates.md` records patterns that were SEEN but not built. Autonomous mode writes candidates; active / passive read them at session start and gently offer the open ones (analogous to the soft old-item reminder), then append a resolution line - built or discarded - to close each out.
+
+## 7. Skills reference
 
 - **audit** - read-only quality gate against requirement and Definition of Done; severity-ranked decision, never a fix. Mandatory before `2_done/`.
 - **diag** - read-only root-cause diagnosis at file:line; the fix is a separate GO-gated step.
@@ -163,12 +173,13 @@ An item may enter `2_done/` only when all hold:
 - **orchestration** - safe, efficient delegation to subagents (count, disjoint files, monitoring, inherited security, return-and-resume).
 - **safety** - hard filesystem-protection and no-autonomous-installs rules; highest priority.
 - **cross-cutting-checklist-generator** - detects scattered concerns and auto-generates a project-local checklist.
+- **skill-capture** - turns a workflow that recurs ~3x in a session into a reusable skill; heuristic and in-session (no counter, no backend), mode-gated (autonomous only notes a candidate, presence modes propose via Ask and build on GO). See section 6.
 - **wsl-env** - reach Windows-side services, processes, and launchers from WSL; self-detecting.
 - **session-active / session-passive / session-autonomous** - per-mode behavior; the active skill holds the shared core.
 
-## 7. Dependencies (honest)
+## 8. Dependencies (honest)
 
-### 7.1 `limit` plugin - recommended prerequisite
+### 8.1 `limit` plugin - recommended prerequisite
 
 Required for two features:
 
@@ -180,10 +191,10 @@ Required for two features:
 
 Without the `limit` plugin these features are silently unavailable. No error is raised; credo just does not run logic that has no data.
 
-### 7.2 `ntfy` - optional
+### 8.2 `ntfy` - optional
 
 Push notifications use `ntfy`. The topic is `personal.ntfy_topic` in the credo config. Unset means ntfy is silently skipped. Nothing else depends on it.
 
-## 8. Testing conventions
+## 9. Testing conventions
 
 Every hook, state, and config mechanism is testable against a temporary HOME (for example `HOME=$(mktemp -d) bash hook.sh`) so tests never touch the real `~/.claude`. Hooks are failure-safe: any error exits 0 with no output and never blocks a prompt or a subagent.

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.24.0
+version: 0.25.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/skills/session-active/SKILL.md
+++ b/plugins/credo/skills/session-active/SKILL.md
@@ -82,6 +82,8 @@ Gently - never as compulsion - surface a few old open items now and then, then l
 Trigger on session start / resume and occasionally during the session. No hook, no
 pushback against new work; the only goal is that old item numbers do not lie forgotten
 forever. The item folders are the source of truth for what is open (credo `items` skill).
+On start / resume, in the same gentle spirit, also offer any open skill candidates left in
+`.credo/skill-candidates.md` - the rule itself lives in the credo `skill-capture` skill.
 
 ## Do not rename or restructure silently (G6, G7)
 
@@ -159,6 +161,8 @@ them - reference each by name when it applies:
 - `orchestration` - how to delegate to subagents safely (disjoint files, sequential
   commit, monitor without flooding, return-and-resume, subagents >= main model).
 - `cross-cutting-checklist-generator` - auto-generated project checklists.
+- `skill-capture` - turn a ~3x-recurring in-session workflow into a reusable skill
+  (mode-gated; propose via Ask in presence modes, candidate-note only in autonomous).
 - `budget` - all API cap / reset rules and the commit-identity gate.
 - `compact-plus` - securing approved work before a context compaction.
 - `wsl-env` - WSL / Windows-side reachability rules (self-detecting; no-op elsewhere).

--- a/plugins/credo/skills/session-autonomous/SKILL.md
+++ b/plugins/credo/skills/session-autonomous/SKILL.md
@@ -77,6 +77,17 @@ new features, invent scope, or make product decisions on the user's behalf. Anyt
 already GO waits (or becomes a deferred question, below); it does not get built
 autonomously.
 
+### Never build a skill autonomously (hard guarantee)
+
+The credo `skill-capture` skill is mode-gated, and autonomous mode takes its strictest
+branch: autonomous mode NEVER builds a skill from a recurring workflow, no matter how often
+the pattern recurs. Building a skill needs an explicit user GO, which an autonomous run does
+not have; a build-on-detection rule would be a showstopper. When you notice the same
+multi-step workflow recur (about three times), append ONE candidate note to
+`.credo/skill-candidates.md` and continue the actual work - do not stop, do not ask, do not
+create the skill. A later presence-mode session picks the candidate up. This is consistent
+with steward-not-initiator: noticing a pattern is fine, acting on it into new tooling is not.
+
 ### Budget caps are always on
 
 Guardrail-availability gate (autonomy never runs without budgets/limits). At autonomous-mode

--- a/plugins/credo/skills/session-passive/SKILL.md
+++ b/plugins/credo/skills/session-passive/SKILL.md
@@ -39,8 +39,8 @@ It covers, all unchanged for passive mode:
   credo `budget` skill; forbidden commit/push -> WARN, work not securable.
 - The credo `safety` skill applies always.
 - The building blocks a session ties together (`items`, `verify`, `requirements-verbatim`,
-  `audit`, `diag`, `orchestration`, `cross-cutting-checklist-generator`, `budget`,
-  `compact-plus`, `wsl-env`).
+  `audit`, `diag`, `orchestration`, `cross-cutting-checklist-generator`, `skill-capture`,
+  `budget`, `compact-plus`, `wsl-env`).
 
 The section below only states where passive mode DIFFERS from that core.
 
@@ -77,6 +77,14 @@ the user's attention is the scarce resource.
 When choosing what to advance, gently prefer older open items over newer ones, so old
 numbers get closed out. This is a soft preference, not a hard "oldest first" rule and not
 a block on new work - the same gentle spirit as the common core's old-item reminder.
+
+### Capture recurring workflows (Ask allowed)
+
+Passive mode has the user reachable for clarifications, so the credo `skill-capture` skill
+applies in its presence-mode form: when a multi-step workflow recurs about three times, and
+when open candidates sit in `.credo/skill-candidates.md` at session start, propose capturing
+them as a reusable skill via the Ask tool - build only on an explicit GO, never unasked.
+Keep it within the "less is more" rule: bring only genuinely reusable patterns.
 
 ### No keep-alive
 

--- a/plugins/credo/skills/skill-capture/SKILL.md
+++ b/plugins/credo/skills/skill-capture/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: skill-capture
+description: >
+  Turn a recurring in-session workflow into a reusable Claude Code skill. Load this the
+  moment you notice you have run the SAME multi-step sequence (same ordered steps or
+  commands, small variation allowed) about three times in the current session, or when
+  open candidates are waiting in .credo/skill-candidates.md at session start or resume. It
+  is heuristic and in-session only - no persistent counter, no tracking backend. Mode-gated
+  like the audit nit-disposition policy: autonomous mode NEVER builds a skill (it only
+  appends a candidate note and keeps working), active / passive / default propose the
+  capture via the Ask tool and build only on an explicit GO. Applies inside subagents too,
+  where the safest branch (autonomous: candidate note only, never ask, never build) is the
+  default whenever the mode cannot be determined.
+---
+
+# skill-capture - recurring workflow becomes a reusable skill
+
+When the same ordered, multi-step workflow keeps recurring in a session, that repetition is
+a signal: the workflow is worth capturing once as a Claude Code skill so it need not be
+re-derived every time. This skill governs how credo notices that repetition and, only with
+the right permission, turns it into a discoverable skill - without inventing any new
+infrastructure.
+
+## Detection heuristic (in-session, no backend)
+
+Detection is purely heuristic and lives entirely in the current session's context. There is
+NO persistent counter, NO tracking file that increments, NO new infrastructure. You notice
+the pattern the same way a person would:
+
+- A candidate is the SAME multi-step sequence - the same ordered steps or commands, small
+  variation allowed (different arguments, paths, or names) - that you have carried out about
+  three times in the running session.
+- One-off actions and trivial single commands are not candidates. The value is in a
+  multi-step ordered sequence that you would otherwise reconstruct from scratch each time.
+- Detection resets with the session. This skill does not try to remember across sessions via
+  a counter; cross-session memory lives only in the two `.credo/` files below, which are
+  written when a pattern is actually noted or built, never as a running tally.
+
+## Mode gating (hard guarantee)
+
+How you act on a detected candidate depends strictly on the session mode, mirroring the
+audit skill's nit-disposition policy (presence modes ask, autonomous acts on a documented
+default). The mode comes from the session-mode inject line.
+
+**Safe default when the mode is not determinable.** A subagent gets no session-mode inject
+line, so its mode is often unknown. When you cannot determine the mode, apply the SAFEST
+branch = the autonomous behavior below: append a candidate note only, never ask, never
+build. This is the same principle by which safety rules always take their strictest reading
+inside subagents - an unknown mode must never fall through to the ask-and-build branch.
+
+- **Autonomous mode - NEVER build a skill, no matter how often the pattern recurs.** A skill
+  needs an explicit user GO, which an autonomous run never has; a build-on-detection rule
+  would be a showstopper. Instead, append ONE candidate note to
+  `.credo/skill-candidates.md` and continue the actual work normally. Never block, never ask,
+  never create the skill. The note is what lets a later presence-mode session pick it up.
+- **Active / passive / default with the user present (main agent, mode determinable) -
+  propose, never auto-create.** Explain the recurring pattern briefly and use the Ask tool to
+  propose capturing it as a skill, with a clear recommendation (default: capture, when the
+  pattern is genuinely reusable). Build the skill ONLY after an explicit GO. Without a GO,
+  either drop it or record it as an open candidate (below) - never create a skill unasked.
+  This ask-and-build branch requires that the mode is actually determinable and the user is
+  reachable; an unknown mode takes the safe default above, not this branch.
+
+This gating is the load-bearing guarantee: autonomous work is never derailed into building a
+skill, and no skill is ever created without the user's explicit GO.
+
+## Where the generated skill goes (standard discovery path)
+
+A generated skill MUST land on a real Claude Code skill-discovery path, or Claude Code will
+never find it. Derive the scope from the workflow, propose the location via Ask, and let the
+user confirm or change it:
+
+- **Repo-specific workflow** (only meaningful in this project) -> `<repo>/.claude/skills/`.
+- **Generally useful workflow** (useful across projects) -> `~/.claude/skills/`.
+
+Do NOT place a generated skill under `.credo/skills/` or anywhere else outside the discovery
+paths - a plain `.credo/skills/` folder is NOT scanned for skills, so a skill written there
+would silently never load. `.credo/` holds only the two tracking files below, never the
+generated skill itself.
+
+## Origin marking (all three, together)
+
+Every skill built from a recurring workflow carries all three origin markers, so it is
+always recognizable as credo-generated and traceable back to its pattern:
+
+1. **Name prefix `credo-<name>`** - the skill's `name` (and folder) starts with `credo-`, so
+   generated skills group visibly in the skills list. Example: `credo-hotfix-pr`.
+2. **Frontmatter marker plus a dated body note** - each generated `SKILL.md` frontmatter
+   carries `origin: credo-repetition`, and the body opens with a short comment naming the
+   source, for example: "Built from a recurring workflow on 2026-07-19." Keep the note to
+   one line.
+3. **Register line** - append one line per built skill to `.credo/generated-skills.md` (see
+   below).
+
+## The two `.credo/` files (append-only, created on first use)
+
+Both files live at the root of `.credo/` (resolve `.credo` via the repo root, same as every
+other credo file), are plain append-only Markdown, and are created the first time they are
+needed - do not pre-create them. Like the rest of `.credo/**` they are git-excluded by
+default, so they stay local unless the project opted into `.credo` versioning.
+
+- **`.credo/generated-skills.md`** - the register of skills that were actually BUILT. One
+  line per built skill: name, path, date, and the observed pattern.
+- **`.credo/skill-candidates.md`** - patterns that were SEEN but not built. Autonomous mode
+  appends here. Active / passive read it at session start and offer the open candidates
+  (below). Append-only: to resolve a candidate you APPEND a resolution line referencing it
+  (built or discarded), you do not rewrite earlier lines. An "open" candidate is one with no
+  later resolution line.
+
+### Example line format
+
+`.credo/generated-skills.md` (one line per built skill):
+
+```
+- 2026-07-19 | credo-hotfix-pr | ~/.claude/skills/credo-hotfix-pr/SKILL.md | pattern: branch -> edit -> commit -> push -> gh pr create, seen ~3x
+```
+
+`.credo/skill-candidates.md` (a candidate, then its later resolution):
+
+```
+- 2026-07-19 | candidate: release bump (edit plugin.yaml + plugin.json version, validate JSON), seen ~3x | scope: repo (marcel-bich-claude-marketplace) | status: open
+- 2026-07-20 | resolved candidate 2026-07-19 (release bump): built as credo-version-bump (<repo>/.claude/skills/credo-version-bump/SKILL.md)
+```
+
+A discarded candidate resolves the same way: `... | resolved candidate <date> (<short>): discarded - <reason>`.
+
+## Session-start loop (presence modes)
+
+In active and passive mode, at session start or resume, read `.credo/skill-candidates.md`
+and gently offer any OPEN candidates (those without a resolution line) - exactly the tone of
+the common-core "Soft old-item reminder": surface a few, recommend, then let it go. No hook,
+no compulsion, no pushing back against the current work; the only goal is that a candidate
+noted by an earlier (often autonomous) session is not forgotten. On a GO, build it and
+append both the register line and a candidate resolution line; on a decline, append a
+discarded resolution line. Autonomous mode does not run this offer loop - it only ever
+appends candidates, never builds.
+
+## KISS / YAGNI
+
+This feature is deliberately behavior-only. It needs NO new shell script, NO tracking
+backend, and NO config options - just this skill's text plus the two Markdown files that
+Claude maintains by hand. Do not add a counter, a hook, or a config key for it unless a
+concrete need actually appears (YAGNI). When you do build a generated skill, keep the skill
+itself minimal and follow the normal skill conventions.
+
+## dogma-first
+
+Where dogma already governs a concern (git rules, language, versioning, linting) for the
+generated skill or its files, follow dogma first and treat credo rules as fallback only.
+DOGMA-PERMISSIONS always take precedence.


### PR DESCRIPTION
## Summary

New credo building-block skill `skill-capture`: when the same multi-step workflow recurs about three times within a session, credo can capture it once as a reusable, discoverable Claude Code skill instead of re-deriving it every time. Detection is in-session and heuristic - no persistent counter, no tracking backend, no new scripts, hooks, or config. Behavior-only: the skill text plus two Markdown files credo maintains by hand.

## Changes

- **`skill-capture` skill.** Detection heuristic (in-session, ~3x same ordered multi-step sequence), mode gating, origin marking, the two `.credo/` files, and the presence-mode session-start offer loop.
- **Mode-gated hard guarantee.** Autonomous mode NEVER builds a skill, no matter how often a pattern recurs - it only appends a candidate note to `.credo/skill-candidates.md` and continues, never blocking. Active / passive / default (user present, mode determinable) explain the pattern and propose the capture via the Ask tool, building only on an explicit GO. When the mode cannot be determined (for example inside a subagent, which gets no mode inject line), the safest branch applies - candidate note only, never ask, never build.
- **Provenance (three markers).** Generated skills use a `credo-` name prefix, an `origin: credo-repetition` frontmatter marker with a one-line dated body note, and a register line appended to `.credo/generated-skills.md`. A second append-only file `.credo/skill-candidates.md` records patterns seen but not built; both live under `.credo/` (git-excluded like the rest).
- **Discovery path.** Generated skills land on a real skill-discovery path (`<repo>/.claude/skills/` or `~/.claude/skills/`, scope proposed via Ask), never under `.credo/skills/` (which is not scanned).
- **Session wiring.** `session-active` and `session-passive` reference the skill and surface open candidates gently at session start (soft-reminder tone); `session-autonomous` states the candidate-note-only guarantee.
- **Docs.** README note, a dedicated top-level guide section, and a psalm topic. Removed brittle absolute skill-count claims that had drifted out of sync.
- Version 0.25.0.

## Test plan

- In active/passive: after a workflow recurs ~3x, credo explains it and offers capture via Ask; on GO a `credo-`prefixed skill is written to the chosen discovery path with the `origin` marker and a register line
- In autonomous: a recurring pattern only appends a candidate line to `.credo/skill-candidates.md`; no skill is built, no question asked, work continues
- Next active/passive session surfaces the open candidate from `.credo/skill-candidates.md` and offers to build it
- A subagent that notices repetition takes the safe default (candidate note only), never ask-and-build
- Both version files read 0.25.0; plugin.json is valid JSON; no AI-trace glyphs in changed files
