### PR TITLE
v0.25.1: id-counter reconciles against the items tree on every allocation

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -78,7 +78,7 @@ The builtin template ships universal, safe-for-everyone defaults (viewports 320/
 
 ### Deterministic id-counter
 
-Item ids come from `scripts/credo-id-next.sh`. The counter file holds the last id given out; allocation is atomic (flock): read, increment, write, print. It never reads the folders to pick a number, so a deleted item id is never reused. Always take an id from the helper; never derive it from folder contents.
+Item ids come from `scripts/credo-id-next.sh`. The counter file holds the last id given out; allocation is atomic (flock): read the counter, scan the items tree, take `max(counter, highest existing id) + 1`, write it back, print it. The counter, not the folder, decides the number - deleting the highest item never lowers the next id, so a deleted id is never reused; the folder scan is only a safety floor that lifts a counter which fell behind the items on disk (merge, clone, backup restore, sync) and warns on stderr when it does. Always take an id from the helper; never hand-pick one.
 
 ## The item workflow
 

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -92,7 +92,7 @@ Personal fields under `personal:` (ntfy topic, commit-identity hint, WSL `lan_ip
 
 ### 3.2 Deterministic id-counter
 
-`scripts/credo-id-next.sh` owns id allocation. The counter file holds the last id given out. Allocation is atomic under flock: read (0 if empty), increment, write, print. It never scans folders to choose a number, so a deleted item id is never reused. A recovery fallback (max existing id plus one) applies only if the counter file is missing. Never derive an id from folder contents; always call the helper.
+`scripts/credo-id-next.sh` owns id allocation. The counter file is the monotone issuing point and holds the last id given out. Allocation is atomic under flock: read the counter (0 if empty, missing, or non-numeric), scan the items tree for the highest existing id, take `base = max(counter, scan)`, write `base + 1`, print it. The counter, not the folder, decides the number, so deleting the highest item does not lower the next id and a deleted id is never reused. The folder scan is a safety floor, not the source of the id: it only lifts a counter that fell behind the items on disk (merge, clone, backup restore, sync), and when it reconciles up it warns on stderr while stdout stays the bare id. Never derive an id from folder contents by hand; always call the helper.
 
 ### 3.3 Project resolution (hub-aware)
 

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.25.0
+version: 0.25.1
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/scripts/credo-id-next.sh
+++ b/plugins/credo/scripts/credo-id-next.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 # credo-id-next - issue the next deterministic, never-reused work-item id.
 #
-# The counter file (.credo/id-counter) holds the last issued number. Issuance
-# is atomic under flock: read n (0 if empty or missing content), n = n + 1,
-# write n back atomically, print n. The counter is NEVER derived from folder
-# contents, so a deleted item id is never reissued.
+# The counter file (.credo/id-counter) is the monotone issuing point: it holds
+# the last number given out. Issuance is atomic under flock: read the counter
+# (0 if empty, missing, or non-numeric), scan the items tree for the highest
+# existing id, take base = max(counter, scan), write base + 1 back atomically,
+# print it.
 #
-# Recovery fallback (only when the counter file is entirely MISSING): scan the
-# items tree for existing ids and set n = max(existing) + 1. A present-but-empty
-# file counts as 0 (next id = 1) by design.
+# The counter, not the folder, decides the number: deleting the highest item
+# does NOT lower the next id, so a deleted id is never reissued. The folder scan
+# is a SAFETY FLOOR, not the source of the id - it only guards against a counter
+# that was rolled back or is stale relative to the items on disk (merge, clone,
+# backup restore, NAS sync). Whenever the scan finds ids above the counter, the
+# counter is reconciled up to them and a drift warning is printed to stderr so
+# the reconciliation is visible rather than silent.
+#
+# stdout carries ONLY the issued id (callers parse stdout); warnings go to stderr.
 #
 # Usage:
 #   credo-id-next.sh                 use the current git repo (or cwd)
@@ -33,7 +40,7 @@ ITEMS_DIR="$CREDO_DIR/items"
 
 mkdir -p "$CREDO_DIR"
 
-# --- recovery scan: highest existing id from item files ----------------------
+# --- scan floor: highest existing id from item files -------------------------
 # Looks at filenames like 124-slug.md and any "id: 124" frontmatter line.
 recover_max_id() {
     local max=0 id
@@ -61,15 +68,25 @@ recover_max_id() {
 exec 9>"$LOCK_FILE"
 flock 9
 
-if [ ! -f "$COUNTER_FILE" ]; then
-    # File missing entirely -> recovery fallback.
-    base="$(recover_max_id)"
-else
-    base="$(tr -d '[:space:]' < "$COUNTER_FILE")"
-    # Empty or non-numeric content counts as 0 (per spec).
-    case "$base" in
-        ''|*[!0-9]*) base=0 ;;
+# Read the counter (missing, empty, or non-numeric all count as 0).
+counter=0
+if [ -f "$COUNTER_FILE" ]; then
+    counter="$(tr -d '[:space:]' < "$COUNTER_FILE")"
+    case "$counter" in
+        ''|*[!0-9]*) counter=0 ;;
     esac
+fi
+
+# Always scan the items tree so a stale/rolled-back counter cannot reissue an id.
+scan="$(recover_max_id)"
+
+# base = max(counter, scan). The counter still governs monotonicity (never-reuse);
+# the scan only lifts a counter that fell behind the items on disk.
+base="$counter"
+if [ "$scan" -gt "$base" ]; then
+    base="$scan"
+    printf 'credo-id-next: counter (%s) was behind existing ids (max %s); reconciled to %s.\n' \
+        "$counter" "$scan" "$((base + 1))" >&2
 fi
 
 next=$((base + 1))

--- a/plugins/credo/skills/items/SKILL.md
+++ b/plugins/credo/skills/items/SKILL.md
@@ -49,7 +49,7 @@ Exactly five required fields. Keep it minimal:
 
 ```yaml
 ---
-id: 124                 # integer from credo-id-next.sh, never derived from folder contents
+id: 124                 # integer from credo-id-next.sh (monotone counter, folder is a safety floor)
 title: Short imperative title
 created: 2026-07-04      # YYYY-MM-DD, the day the item was created (in 1_clarify)
 type: feature           # one of: bug | optimization | feature | question | chore
@@ -73,14 +73,18 @@ when it actually applies, free-form in the body.
 - Frontmatter `id:` matches the number in the filename.
 - Reference an item elsewhere as `#124` (plus its date/short context - transcript line
   numbers are not stable references).
-- **Get ids only from the counter, never from folder contents.** Issue the next id with:
+- **Get ids only from the counter helper, never compute one yourself.** Issue the next id with:
 
   ```
   "${CLAUDE_PLUGIN_ROOT}/scripts/credo-id-next.sh"
   ```
 
-  It is deterministic and never-reuse: a deleted `#124` is never reissued. Do not compute
-  an id by scanning existing files or taking `max+1` yourself - that reuses deleted ids.
+  It is deterministic and never-reuse: the monotone counter, not the folder, decides the
+  number, so a deleted `#124` is never reissued. On each call the helper also scans the
+  items tree as a safety floor and takes `max(counter, highest existing id) + 1`, so a
+  stale or rolled-back counter (merge, clone, restore, sync) never hands out an id that is
+  already in use (it warns on stderr when it reconciles). Do not compute an id by scanning
+  files or taking `max+1` yourself - that reuses deleted ids and skips the lock.
 
 ## Body sections
 

--- a/plugins/credo/skills/migrate/SKILL.md
+++ b/plugins/credo/skills/migrate/SKILL.md
@@ -99,10 +99,13 @@ item cutting, and the self-audit) to subagents per the `orchestration` skill, an
   and `screenshots` are ALWAYS excluded so personal values and binaries never get
   committed.
 - Also git-exclude the migration working folder (step 4).
-- **`id-counter` = the highest existing legacy id** in the repo, so new ids never collide
-  and old numbers are never reused. If there are no legacy ids, leave it empty (treated as 0).
-  Issue every new id afterwards with `"${CLAUDE_PLUGIN_ROOT}/scripts/credo-id-next.sh"`,
-  never by scanning folders or taking `max+1` yourself.
+- **`id-counter` = at least the highest existing legacy id** in the repo, so new ids never
+  collide and old numbers are never reused. If there are no legacy ids, leave it empty
+  (treated as 0). Issue every new id afterwards with
+  `"${CLAUDE_PLUGIN_ROOT}/scripts/credo-id-next.sh"`, never by scanning folders or taking
+  `max+1` yourself. The helper also scans the items tree on each call as a safety floor, so
+  even if the counter is set too low it reconciles up to the highest existing id (and warns
+  on stderr) rather than reissuing a used id.
 
 ## 4. Working folder (recommended)
 
@@ -205,7 +208,8 @@ agent that did the migration - a fresh reviewer catches self-inconsistencies. Ch
 - file names (lowercase-kebab; `<id>-slug.md` for items);
 - mandatory frontmatter present and no `status` / `marker` field;
 - no duplicate ids; no broken internal references;
-- `id-counter` == the highest id in use;
+- `id-counter` >= the highest id in use (equal in the common case; the helper's scan floor
+  reconciles it up if it ever falls behind);
 - completeness: cross-check every open id / task mentioned in the sources against the
   created items, report real gaps, and confirm items correctly absent because already done.
 


### PR DESCRIPTION
## Summary

Bugfix for work-item id allocation. `credo-id-next.sh` scanned the items tree only when the counter file was entirely missing; otherwise it trusted the counter value blindly. A counter that had fallen behind the items on disk - after a branch merge, a clone, a backup restore, or a NAS/file sync that rolled the counter back while newer items already existed - would then reissue an id that was already in use.

## Fix

Under the same `flock`, every allocation now:

- reads the counter (missing / empty / non-numeric all count as 0),
- scans the items tree for the highest existing id,
- takes `base = max(counter, scan)` and issues `base + 1`,
- writes the new value back atomically (tmp + `mv -f`).

The counter, not the folder, still decides the number: deleting the highest item does not lower the next id, so a deleted id is never reused. The folder scan is purely a safety floor that lifts a stale or rolled-back counter back above the items on disk. When the scan is ahead of the counter, a drift warning goes to stderr so the reconciliation is visible instead of silent; stdout still carries only the id, so callers that parse it are unaffected.

The counter stays versioned in tracked mode by design (cross-machine visibility of the last id and conflict forensics); the fix makes a rolled-back or merge-resolved counter self-heal on the next allocation.

## Test plan

- Empty / missing counter, no items - issues 1
- Counter behind the items (counter 12, item id 25 on disk) - issues 26 and warns on stderr; stdout is only the id
- Highest item deleted (counter 25, only ids <= 24 remain) - issues 26, never reuses 25, no warning
- Many concurrent allocations under flock - all ids unique, none duplicated
- stdout carries only the id in every case; warnings appear only on stderr
- Both version files read 0.25.1; plugin.json is valid JSON; no AI-trace glyphs in changed files
