### PR TITLE
v0.26.0: one-item-per-Ask-round discipline and session-mode awareness

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.25.1",
+  "version": "0.26.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -31,7 +31,7 @@ Skills and hooks are auto-discovered by Claude Code from the `skills/` and `hook
 
 ## Session modes
 
-The mode is per session and set with a command. It is stored on disk keyed by the session id, so it survives compaction, new sessions, and subagents. The `UserPromptSubmit` hook re-injects a one-line reminder of the active mode on every prompt, and names the matching skill to load.
+The mode is per session and set with a command. It is stored on disk keyed by the session id, so it survives compaction, new sessions, and subagents. The `UserPromptSubmit` hook re-injects a one-line reminder of the active mode on every prompt, and names the matching skill to load. A second `UserPromptSubmit` hook injects the current local date and time on every prompt (mode-independent), so the agent is date/time-aware: when no mode is set it proposes a fitting presence mode via Ask (never autonomous, never silently), and it mentions the active mode in normal output now and then, especially after a long gap since the last prompt. An autonomous run is never interrupted by a mode-change question.
 
 - **active** (`/credo:session-active`) - intensive live collaboration with the user at the keyboard. Progress is logged via the limit thresholds and compact-plus, open GO items are picked up alongside, clarifications happen during subagent waits. No keep-alive.
 - **passive** (`/credo:session-passive`) - the agent carries most of the work while the user is reachable only for clarifications. Every item is pushed toward a full GO; less is more, so only genuinely ambiguous items go back to the user. No keep-alive.

--- a/plugins/credo/commands/psalm.md
+++ b/plugins/credo/commands/psalm.md
@@ -85,7 +85,9 @@ credo runs a session in one of three exclusive modes. The active mode is re-inje
 - `/credo:session-passive` - the agent carries most of the work; you stay reachable for clarifications only, no keep-alive.
 - `/credo:session-autonomous` - approved GO items worked unattended, keep-alive on (hook-enforced: a registered Stop hook blocks a stop without a scheduled wake-up), budget caps enforced, ntfy per task and question, progress secured via compact-plus. It self-bootstraps on an unambiguous full-autonomy grant, needing no host CLAUDE.md line.
 
-Pick the mode that matches how present you are. Switch any time by running the matching command.
+Pick the mode that matches how present you are. Switch any time by running the matching command. credo injects the local date and time on every prompt, so the agent is time-aware: when no mode is set it proposes a fitting presence mode via Ask (never autonomous, never silently), and it mentions the active mode now and then, especially after a long gap. An autonomous run is never interrupted by a mode-change question - switch it only with an explicit command.
+
+When clarifying or proposing a GO in a presence mode, the agent works one item per Ask round rather than dumping many items at once (see the session-active common core).
 
 ### Topic: Item Lifecycle and Definition of Done
 

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -20,8 +20,9 @@ Design principles:
 
 - **commands/** - eight slash commands: `psalm`, `setup`, `migrate`, `project`, `session-init`, and the three mode setters `session-active`, `session-passive`, `session-autonomous`.
 - **skills/** - the auto-discovered skills (see the skills reference section). Each auto-triggers when it applies, including inside subagents.
-- **hooks/** - four hooks are registered in `hooks/hooks.json`:
+- **hooks/** - five hooks are registered in `hooks/hooks.json`:
   - `session-mode-inject.sh` (`UserPromptSubmit`) - re-injects the active session mode on every prompt and names the skill to load.
+  - `credo-datetime-inject.sh` (`UserPromptSubmit`) - injects the current local date and time on every prompt, independent of session mode (makes the agent date/time-aware and gives the mode-awareness rules a clock signal). Gated by `CREDO_DATETIME_INJECT` (default on).
   - `credo-autonomy-clear.sh` (`UserPromptSubmit`) - a real user message turns autonomy off (drops the flag, sets the paused opt-out).
   - `credo-subagent-inject.sh` (`SubagentStart`) - primes every subagent with the load-bearing rules.
   - `credo-autonomy-keepalive.sh` (`Stop`) - in autonomous mode, blocks a stop that has no scheduled self-wake and instructs the agent to call ScheduleWakeup.
@@ -123,6 +124,8 @@ The active skill defines the common core shared by all three; passive and autono
 
 Honest note on keep-alive: autonomous mode sets the `credo-autonomy-active` flag, and a registered `Stop` hook (`credo-autonomy-keepalive.sh`) enforces the keep-alive discipline - if you try to end the turn without a marked self-wake, it blocks the stop and instructs you to call `ScheduleWakeup` now; the registered `UserPromptSubmit` hook (`credo-autonomy-clear.sh`) turns autonomy off on any real user message (section 2.1). This is enforcement of the nudge, not a guarantee of infinite wakefulness: the hook forces the block plus instruction, but staying awake still depends on the model then calling `ScheduleWakeup`. It is loop-safe (at most one forced continuation per stop attempt, via the `stop_hook_active` guard) and completely inert outside autonomous mode.
 
+**Mode awareness.** credo injects the current local date and time on every prompt (the `credo-datetime-inject.sh` hook, section 2.1), independent of session mode, so the agent is date/time-aware and can compare successive timestamps to sense how long ago the last user prompt was. Three behavior rules build on this: (1) when no mode is set, the agent infers a fitting presence mode and proposes it via the Ask tool rather than adopting one silently - autonomous is never inferred or auto-set, only entered via `/credo:session-autonomous` or on an explicit request; (2) the agent mentions the active mode in normal output from time to time, especially after a large time gap - a lightweight, behavior-based nudge, not a guaranteed timer; (3) in autonomous mode this is switched off: an autonomous run is NEVER interrupted by an Ask about a mode change, even if the user keeps prompting - a switch happens only on an explicit user instruction. The suggestion cadence is gentle (session start or when the work clearly implies a mode), never per turn.
+
 ## 5. The item workflow: how-to
 
 **Task backend (`.credo/config: task_backend`).** credo's item model is the default task system, but it can stand down in favour of get-shit-done. It is config-driven: set `task_backend` in `.credo/config` (via the config cascade builtin < global < project) to `credo` (default), `gsd`, or `none`. The `CREDO_TASK_BACKEND` env var overrides the config when set and non-empty. Anything unset, empty, or unknown behaves like `credo`, so the default behaviour is unchanged, and any resolution error falls back to `credo`. `/credo:setup` writes `task_backend: gsd` for you when you choose GSD.
@@ -141,6 +144,8 @@ The rest of this section describes the `credo` backend.
 7. Only the user moves an item to `items/3_verified/`.
 
 Parked work goes under `items/parked/{hold,future}`; abandoned work under `items/4_archived/`.
+
+**Ask discipline (presence modes).** When clarifying items or proposing a GO in an active or passive session, handle one item per Ask round: explain the single item with concrete examples and consequences, then put its questions and GO proposal into its own Ask round, one round per item id. Do not bundle several items into one message or a flowing-text dump. Within a single round, asking several independent questions at once is fine and encouraged; a question whose framing depends on another answer goes into a later round. This does not apply in autonomous mode (no interactive Ask rounds). The rule lives in the common core (session-active skill).
 
 ### 5.1 Definition of Done gate
 

--- a/plugins/credo/hooks/credo-datetime-inject.sh
+++ b/plugins/credo/hooks/credo-datetime-inject.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# credo-datetime-inject.sh - credo plugin (UserPromptSubmit hook)
+#
+# Purpose: inject the current local date and time into the model context on
+# EVERY prompt, independent of the credo session mode. Two goals: make the agent
+# generally date/time-aware, and give the mode-awareness rules a clock signal
+# (compare successive injected timestamps to sense a large gap since the last
+# user prompt). This hook does NOT gate on session mode or session_id - it always
+# injects while enabled.
+#
+# Output: hookSpecificOutput.additionalContext with suppressOutput true (model
+# context only, not the user chat). One short line, for example:
+#   [credo-time] 2026-07-22 14:33 (Tue), TZ CEST
+#
+# No dependency on the limit plugin or any other plugin. jq is optional: used
+# when present, otherwise a hand-built JSON string (the content is a controlled
+# date format that is additionally stripped of quotes/backslashes, so it is safe
+# to embed without jq escaping).
+#
+# Failure-safe: ANY problem -> exit 0 with no output. Never block a prompt.
+
+# --- toggle (default on) ---
+[[ "${CREDO_DATETIME_INJECT:-true}" == "true" ]] || exit 0
+
+# Drain stdin so the producer never blocks on a full pipe; the content is unused
+# (this hook injects regardless of session_id or mode).
+cat >/dev/null 2>&1
+
+# --- build the local date/time line ---
+now=$(date '+%Y-%m-%d %H:%M (%a), TZ %Z' 2>/dev/null) || exit 0
+[[ -n "$now" ]] || exit 0
+line="[credo-time] ${now}"
+
+# Defensive: keep the manual-JSON path safe even if the locale injected an odd
+# character - strip backslashes, double quotes, and any control characters.
+line=${line//\\/}
+line=${line//\"/}
+line=$(printf '%s' "$line" | tr -d '[:cntrl:]' 2>/dev/null) || exit 0
+[[ -n "$line" ]] || exit 0
+
+# --- emit JSON (suppressOutput so the user chat is not flooded) ---
+if command -v jq >/dev/null 2>&1; then
+    jq -n --arg ctx "$line" \
+        '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}, suppressOutput: true}' 2>/dev/null
+else
+    printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"},"suppressOutput":true}\n' "$line"
+fi
+
+exit 0

--- a/plugins/credo/hooks/hooks.json
+++ b/plugins/credo/hooks/hooks.json
@@ -10,6 +10,11 @@
           },
           {
             "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-datetime-inject.sh",
+            "timeout": 10
+          },
+          {
+            "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-autonomy-clear.sh",
             "timeout": 10
           }

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.25.1
+version: 0.26.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/credo/skills/items/SKILL.md
+++ b/plugins/credo/skills/items/SKILL.md
@@ -203,7 +203,9 @@ Prefer the move helper - it is atomic, never deletes, and refuses the user-only 
 Valid transitions (folder = status):
 
 - `1_clarify -> 2_go` once the user gives an explicit GO (go-gate: only `2_go` is
-  buildable; `1_clarify` is not).
+  buildable; `1_clarify` is not). In a presence session, clarify and propose that GO one
+  item at a time, each item in its own Ask round - see "One item per Ask round" in the
+  common core (session-active skill).
 - `2_go -> 2_done` only after the full Definition of Done gate above passes.
 - `2_done -> 1_clarify` when a bug is found (see above).
 - any -> `parked/hold` (external block) or `parked/future` (deferred), or `4_archived`

--- a/plugins/credo/skills/session-active/SKILL.md
+++ b/plugins/credo/skills/session-active/SKILL.md
@@ -58,6 +58,27 @@ The default channel for a clarification is ALWAYS the Ask tool. Short decisions 
 choices go through Ask. For long lists, use prose in the normal message instead - Ask
 truncates - but the decision itself still comes back through Ask where practical.
 
+## One item per Ask round (active and passive only)
+
+When clarifying or proposing a GO for credo items in a presence session, handle them one
+item at a time. Take a single item, explain it briefly - with concrete examples and the
+consequences of the choice - then put that item's questions and GO proposal into its own
+Ask round, one round per item id. Never bundle several items into one message or a
+flowing-text dump of questions; that floods the user and makes it impossible to respond to
+each point. Prefer many small, focused Ask rounds over one large one.
+
+Within a single Ask round, asking several questions at once (the Ask tool's
+multiple-question form) is allowed and encouraged - it lets the user settle several open
+points in one pass. Only batch questions that are independent of each other; never put a
+question whose framing depends on another question's answer into the same round - split
+those into sequential rounds, or it gets confusing.
+
+This is orthogonal to passive mode's "less is more" (which limits which items reach the
+user at all): still bring only the genuinely ambiguous items and self-resolve the rest, but
+present each one you do bring in its own round. Trivial, self-evident fixes still need no
+question. This rule does not apply in autonomous mode, which runs unattended without
+interactive Ask rounds.
+
 ## A bug report is not an immediate fix (G2)
 
 When the user reports a bug, do not jump straight to fixing it if there is interpretation
@@ -84,6 +105,33 @@ pushback against new work; the only goal is that old item numbers do not lie for
 forever. The item folders are the source of truth for what is open (credo `items` skill).
 On start / resume, in the same gentle spirit, also offer any open skill candidates left in
 `.credo/skill-candidates.md` - the rule itself lives in the credo `skill-capture` skill.
+
+## Suggest a session mode when none is set (active and passive only)
+
+When no session mode is set (the inject line reports the no-mode default), do not silently
+adopt one. Infer from the context which presence mode fits - active for intensive live
+collaboration, passive when you carry most of the work and the user is only reachable for
+clarifications - and propose it to the user via the Ask tool; the user confirms. Use the
+same gentle cadence as the soft old-item reminder: raise it at session start or when the
+work clearly implies a mode, not every turn, and never nag. Autonomous mode is NEVER
+inferred, proposed, or set automatically - it is entered only via
+`/credo:session-autonomous` or on an explicit user request (see the credo
+`session-autonomous` skill).
+
+When the mode is not determinable at all - for example inside a subagent, which gets no
+session-mode inject line - apply the safest branch: do NOT propose a mode and do NOT ask
+via Ask. This mirrors the credo `skill-capture` skill's rule for a subagent without an
+inject line: when you cannot determine the mode, take the safest branch rather than asking.
+
+## Mention the active mode from time to time
+
+Now and then, name the current session mode in your normal output - especially when the
+session has been running for a while, or when the last user prompt is a long time ago (a
+large time gap). credo injects the local date and time on every prompt (the
+`credo-datetime-inject` hook); compare the current injected timestamp with the previous one
+to sense such a gap. This is a lightweight, behavior-based nudge, not a guaranteed-reliable
+timer: the injected timestamps are your only clock signal and you have no other reliable
+clock, so treat this as a soft reminder and do not nag.
 
 ## Do not rename or restructure silently (G6, G7)
 

--- a/plugins/credo/skills/session-autonomous/SKILL.md
+++ b/plugins/credo/skills/session-autonomous/SKILL.md
@@ -77,6 +77,17 @@ new features, invent scope, or make product decisions on the user's behalf. Anyt
 already GO waits (or becomes a deferred question, below); it does not get built
 autonomously.
 
+### Never interrupt an autonomous run for a mode change (hard rule)
+
+In autonomous mode the agent NEVER asks via the Ask tool about switching mode - not even
+if the user keeps prompting during the autonomous run. An autonomous run must not be
+interrupted for a mode-awareness question. At most, the agent may mention in normal output
+that a mode change has to be made manually (via a `/credo:session-*` command) or on an
+explicit user request; it never raises an Ask round to propose one. A mode switch happens
+only on an explicit user instruction. This is the exception to the common core's
+"Suggest a session mode when none is set" rule: that Ask-based suggestion logic applies
+only in presence or no-mode sessions, never in autonomous.
+
 ### Never build a skill autonomously (hard guarantee)
 
 The credo `skill-capture` skill is mode-gated, and autonomous mode takes its strictest

--- a/plugins/credo/skills/session-passive/SKILL.md
+++ b/plugins/credo/skills/session-passive/SKILL.md
@@ -70,7 +70,8 @@ This is the defining passive-mode rule. Do NOT over-ask. Bring only the genuinel
 ambiguous items to the user, through the Ask tool. Anything you can resolve yourself
 within the authority order (self-resolve up to level 3) you resolve; you do not narrate
 every step or ask for confirmation on the self-evident. Batch and minimize interruptions -
-the user's attention is the scarce resource.
+the user's attention is the scarce resource. Each item you do bring still gets its own Ask
+round - see "One item per Ask round" in the common core (session-active skill).
 
 ### Gently prefer older items first
 


### PR DESCRIPTION
## Summary

Two related additions that make presence sessions easier to follow: a one-item-at-a-time Ask discipline, and session-mode awareness (the agent surfaces which mode is running and proposes one when none is set). Both are behavior rules in the session skills plus one small, self-contained hook - no dependency on the limit plugin.

## Changes

### Ask discipline (active / passive)

- Clarifications and GO proposals are handled one item at a time: explain the item briefly with examples and consequences, then put that item's questions and GO into its own Ask round. Never bundle several items into one message or a flowing-text dump.
- Within one Ask round, batching several independent questions is allowed and encouraged; questions whose framing depends on a prior answer go into separate, sequential rounds.
- Stated as orthogonal to passive mode's "less is more" (which limits which items reach the user at all). Does not apply in autonomous mode.

### Session-mode awareness

- **New hook `credo-datetime-inject.sh`** injects the current local date and time on every prompt, independent of the session mode, with no dependency on the limit plugin. It makes the agent date/time-aware and gives the mode rules a clock signal (compare successive timestamps to sense a large gap). Failure-safe (any problem exits 0 without blocking the prompt), `suppressOutput`, and works without jq via a hardened manual-JSON path.
- **No mode set** - the agent infers a fitting presence mode and proposes it via Ask; it never adopts one silently, and autonomous is never inferred, proposed, or set automatically. When the mode is not determinable (for example inside a subagent with no inject line), the safest branch applies: do not propose and do not ask (mirrors the skill-capture rule).
- **Autonomous** - an autonomous run is never interrupted by a mode-change question, even if the user keeps prompting; at most it notes in output that a switch is manual. A switch happens only on an explicit user request or command.
- **Periodic mention** - the agent names the active mode in normal output from time to time, especially after a long gap since the last prompt. Honest by design: the injected timestamps are the only clock signal, so this is a soft nudge, not a guaranteed timer.

### Docs and version

- Guide, README, and psalm updated; the guide's hook count is reconciled to five.
- Version 0.26.0.

## Test plan

- Hook: normal stdin, empty stdin, broken stdin, toggle off, and a no-jq environment all exit 0 with valid JSON (or no output when toggled off); hooks.json and plugin.json validate
- Active/passive: multiple items are presented in separate Ask rounds, not one dump; independent questions can share a round
- No mode set: a presence mode is proposed via Ask, never adopted silently; autonomous is never auto-proposed
- Subagent / mode not determinable: no mode proposal and no Ask
- Autonomous: no mode-change Ask even while the user keeps prompting
- Both version files read 0.26.0; no AI-trace glyphs; no personal data in the skills
