### PR TITLE
credo v0.27.0 + limit v2.27.0: keep injected time/limits fresh

### DIFF
--- a/plugins/credo/.claude-plugin/plugin.json
+++ b/plugins/credo/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "credo",
-  "version": "0.26.0",
+  "version": "0.27.0",
   "description": "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent",
   "keywords": [
     "workflow",

--- a/plugins/credo/README.md
+++ b/plugins/credo/README.md
@@ -31,7 +31,7 @@ Skills and hooks are auto-discovered by Claude Code from the `skills/` and `hook
 
 ## Session modes
 
-The mode is per session and set with a command. It is stored on disk keyed by the session id, so it survives compaction, new sessions, and subagents. The `UserPromptSubmit` hook re-injects a one-line reminder of the active mode on every prompt, and names the matching skill to load. A second `UserPromptSubmit` hook injects the current local date and time on every prompt (mode-independent), so the agent is date/time-aware: when no mode is set it proposes a fitting presence mode via Ask (never autonomous, never silently), and it mentions the active mode in normal output now and then, especially after a long gap since the last prompt. An autonomous run is never interrupted by a mode-change question.
+The mode is per session and set with a command. It is stored on disk keyed by the session id, so it survives compaction, new sessions, and subagents. The `UserPromptSubmit` hook re-injects a one-line reminder of the active mode on every prompt, and names the matching skill to load. A second hook injects the current local date and time (mode-independent) - on every prompt via `UserPromptSubmit`, and additionally on `PostToolUse` (throttled + delta-guarded) so the clock stays fresh during long autonomous runs instead of freezing at the last prompt. This keeps the agent date/time-aware: when no mode is set it proposes a fitting presence mode via Ask (never autonomous, never silently), and it mentions the active mode in normal output now and then, especially after a long gap since the last prompt. An autonomous run is never interrupted by a mode-change question.
 
 - **active** (`/credo:session-active`) - intensive live collaboration with the user at the keyboard. Progress is logged via the limit thresholds and compact-plus, open GO items are picked up alongside, clarifications happen during subagent waits. No keep-alive.
 - **passive** (`/credo:session-passive`) - the agent carries most of the work while the user is reachable only for clarifications. Every item is pushed toward a full GO; less is more, so only genuinely ambiguous items go back to the user. No keep-alive.
@@ -122,7 +122,7 @@ Auto-discovered under `skills/`. Each auto-triggers when it applies, including i
 
 ## Subagent self-sufficiency
 
-credo primes every subagent at start. The `SubagentStart` hook (`credo-subagent-inject.sh`) injects the load-bearing rules (security, quality gates, honesty, delegation, output hygiene) into each subagent before its first prompt, for all subagent types. This complements the skill descriptions, which are written to auto-trigger inside subagents as well. So even a main agent that only delegates gets correct results, independently of its own context state.
+credo primes every subagent at start. The `SubagentStart` hook (`credo-subagent-inject.sh`) injects the load-bearing rules (security, quality gates, honesty, delegation, output hygiene) into each subagent before its first prompt, for all subagent types. It also injects a fresh, authoritative time (and best-effort live budget from the statusline cache) so a subagent works from the real clock instead of the possibly frozen time/limit values inherited from the main agent's context. This complements the skill descriptions, which are written to auto-trigger inside subagents as well. So even a main agent that only delegates gets correct results, independently of its own context state.
 
 ## Dependencies
 

--- a/plugins/credo/docs/credo-guide.md
+++ b/plugins/credo/docs/credo-guide.md
@@ -22,7 +22,7 @@ Design principles:
 - **skills/** - the auto-discovered skills (see the skills reference section). Each auto-triggers when it applies, including inside subagents.
 - **hooks/** - five hooks are registered in `hooks/hooks.json`:
   - `session-mode-inject.sh` (`UserPromptSubmit`) - re-injects the active session mode on every prompt and names the skill to load.
-  - `credo-datetime-inject.sh` (`UserPromptSubmit`) - injects the current local date and time on every prompt, independent of session mode (makes the agent date/time-aware and gives the mode-awareness rules a clock signal). Gated by `CREDO_DATETIME_INJECT` (default on).
+  - `credo-datetime-inject.sh` (`UserPromptSubmit` + `PostToolUse`) - injects the current local date and time, independent of session mode (makes the agent date/time-aware and gives the mode-awareness rules a clock signal). On every prompt via `UserPromptSubmit`; additionally on `PostToolUse` during long autonomous runs where no user prompt arrives, so the clock does not freeze at the last prompt's value. The `PostToolUse` path is throttled (`CREDO_DATETIME_INJECT_INTERVAL`, default 120s) and delta-guarded (only when the rendered minute changed), and since `PostToolUse` fires only on tool activity, idle waits inject nothing. Gated by `CREDO_DATETIME_INJECT` (default on).
   - `credo-autonomy-clear.sh` (`UserPromptSubmit`) - a real user message turns autonomy off (drops the flag, sets the paused opt-out).
   - `credo-subagent-inject.sh` (`SubagentStart`) - primes every subagent with the load-bearing rules.
   - `credo-autonomy-keepalive.sh` (`Stop`) - in autonomous mode, blocks a stop that has no scheduled self-wake and instructs the agent to call ScheduleWakeup.

--- a/plugins/credo/hooks/credo-datetime-inject.sh
+++ b/plugins/credo/hooks/credo-datetime-inject.sh
@@ -1,35 +1,53 @@
 #!/usr/bin/env bash
-# credo-datetime-inject.sh - credo plugin (UserPromptSubmit hook)
+# credo-datetime-inject.sh - credo plugin (UserPromptSubmit + PostToolUse hook)
 #
-# Purpose: inject the current local date and time into the model context on
-# EVERY prompt, independent of the credo session mode. Two goals: make the agent
-# generally date/time-aware, and give the mode-awareness rules a clock signal
-# (compare successive injected timestamps to sense a large gap since the last
-# user prompt). This hook does NOT gate on session mode or session_id - it always
-# injects while enabled.
+# Purpose: inject the current local date and time into the model context so the
+# agent stays date/time-aware AND the mode-awareness rules have a live clock
+# signal. Two events feed it:
+#   - UserPromptSubmit: inject on EVERY prompt (fresh, cheap, user turns are rare).
+#   - PostToolUse: inject during long autonomous runs where no user prompt arrives
+#     for many minutes, so the clock does not freeze at the last prompt's value.
+#     Throttled (default 120s) and delta-guarded (only when the rendered line
+#     actually changed) so it does not accumulate a line per tool call. Because
+#     PostToolUse only fires on real tool activity, idle waits inject nothing.
 #
 # Output: hookSpecificOutput.additionalContext with suppressOutput true (model
 # context only, not the user chat). One short line, for example:
 #   [credo-time] 2026-07-22 14:33 (Tue), TZ CEST
 #
-# No dependency on the limit plugin or any other plugin. jq is optional: used
-# when present, otherwise a hand-built JSON string (the content is a controlled
-# date format that is additionally stripped of quotes/backslashes, so it is safe
-# to embed without jq escaping).
+# Per-session throttle/delta state (PostToolUse only): a small json under /tmp
+# keyed by session_id. UserPromptSubmit never touches it (always injects).
+#
+# No dependency on the limit plugin or any other plugin. jq is optional on the
+# UserPromptSubmit path (hand-built JSON is safe: the content is a controlled date
+# format stripped of quotes/backslashes/control chars). The PostToolUse path needs
+# jq for the state file; without jq it simply injects unthrottled like before.
 #
 # Failure-safe: ANY problem -> exit 0 with no output. Never block a prompt.
 
 # --- toggle (default on) ---
 [[ "${CREDO_DATETIME_INJECT:-true}" == "true" ]] || exit 0
 
-# Drain stdin so the producer never blocks on a full pipe; the content is unused
-# (this hook injects regardless of session_id or mode).
-cat >/dev/null 2>&1
+# --- config (env-overridable) ---
+INTERVAL="${CREDO_DATETIME_INJECT_INTERVAL:-120}"   # seconds between PostToolUse injects
+
+# --- read hook stdin (event + session_id); drain it either way so the producer
+#     never blocks on a full pipe ---
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+event="UserPromptSubmit"
+session_id=""
+if command -v jq >/dev/null 2>&1 && [[ -n "$INPUT" ]]; then
+    event=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "UserPromptSubmit"' 2>/dev/null) || event="UserPromptSubmit"
+    session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null) || session_id=""
+    [[ "$event" == "null" ]] && event="UserPromptSubmit"
+    [[ "$session_id" == "null" ]] && session_id=""
+fi
 
 # --- build the local date/time line ---
-now=$(date '+%Y-%m-%d %H:%M (%a), TZ %Z' 2>/dev/null) || exit 0
-[[ -n "$now" ]] || exit 0
-line="[credo-time] ${now}"
+now_line=$(date '+%Y-%m-%d %H:%M (%a), TZ %Z' 2>/dev/null) || exit 0
+[[ -n "$now_line" ]] || exit 0
+line="[credo-time] ${now_line}"
 
 # Defensive: keep the manual-JSON path safe even if the locale injected an odd
 # character - strip backslashes, double quotes, and any control characters.
@@ -38,12 +56,49 @@ line=${line//\"/}
 line=$(printf '%s' "$line" | tr -d '[:cntrl:]' 2>/dev/null) || exit 0
 [[ -n "$line" ]] || exit 0
 
-# --- emit JSON (suppressOutput so the user chat is not flooded) ---
+# --- PostToolUse: throttle + delta-guard via per-session state ---
+if [[ "$event" == "PostToolUse" ]]; then
+    # Without jq or a usable session_id we cannot keep state safely -> stay silent
+    # on the tool-call path rather than inject on every single tool call.
+    command -v jq >/dev/null 2>&1 || exit 0
+    [[ -n "$session_id" ]] || exit 0
+    # Guard against path tricks in the session_id (must be a plain token).
+    case "$session_id" in
+        *[!A-Za-z0-9._-]*) exit 0 ;;
+    esac
+
+    state_file="/tmp/claude-mb-credo-time-state_${session_id}.json"
+    now_ts=$(date +%s 2>/dev/null) || exit 0
+
+    last_ts=0; last_line=""
+    if [[ -f "$state_file" ]]; then
+        last_ts=$(jq -r '.last_ts // 0' "$state_file" 2>/dev/null) || last_ts=0
+        last_line=$(jq -r '.last_line // ""' "$state_file" 2>/dev/null) || last_line=""
+        [[ "$last_line" == "null" ]] && last_line=""
+    fi
+    [[ "$last_ts" =~ ^[0-9]+$ ]] || last_ts=0
+
+    # Throttle: not enough time since the last inject -> skip.
+    [[ $((now_ts - last_ts)) -ge "$INTERVAL" ]] || exit 0
+    # Delta-guard: the rendered (minute-granular) line has not changed -> skip.
+    [[ "$line" != "$last_line" ]] || exit 0
+
+    # Persist state (only when we are about to inject).
+    tmp=$(mktemp 2>/dev/null) && {
+        jq -n --argjson last_ts "$now_ts" --arg last_line "$line" \
+            '{last_ts: $last_ts, last_line: $last_line}' > "$tmp" 2>/dev/null \
+            && mv -f "$tmp" "$state_file" 2>/dev/null
+        rm -f "$tmp" 2>/dev/null
+    }
+fi
+
+# --- emit JSON (suppressOutput so the user chat is not flooded); hookEventName
+#     mirrors the firing event so the host attributes the context correctly ---
 if command -v jq >/dev/null 2>&1; then
-    jq -n --arg ctx "$line" \
-        '{hookSpecificOutput: {hookEventName: "UserPromptSubmit", additionalContext: $ctx}, suppressOutput: true}' 2>/dev/null
+    jq -n --arg ev "$event" --arg ctx "$line" \
+        '{hookSpecificOutput: {hookEventName: $ev, additionalContext: $ctx}, suppressOutput: true}' 2>/dev/null
 else
-    printf '{"hookSpecificOutput":{"hookEventName":"UserPromptSubmit","additionalContext":"%s"},"suppressOutput":true}\n' "$line"
+    printf '{"hookSpecificOutput":{"hookEventName":"%s","additionalContext":"%s"},"suppressOutput":true}\n' "$event" "$line"
 fi
 
 exit 0

--- a/plugins/credo/hooks/credo-subagent-inject.sh
+++ b/plugins/credo/hooks/credo-subagent-inject.sh
@@ -32,6 +32,12 @@ INPUT=$(cat 2>/dev/null) || exit 0
 agent_type=$(printf '%s' "$INPUT" | jq -r '.agent_type // ""' 2>/dev/null) || agent_type=""
 [[ "$agent_type" == "null" ]] && agent_type=""
 
+# session_id is used best-effort to read the statusline cache for live budget
+# numbers; may differ from the main agent's session (then the cache is absent and
+# we simply omit the budget part - the time part never depends on it).
+session_id=$(printf '%s' "$INPUT" | jq -r '.session_id // ""' 2>/dev/null) || session_id=""
+[[ "$session_id" == "null" ]] && session_id=""
+
 # --- the credo rule block injected into every subagent ---
 read -r -d '' rules <<'RULES'
 credo rules apply inside this subagent, independently of the main agent - follow them yourself, do not assume the main agent already handled them.
@@ -66,6 +72,42 @@ fi
 rules="${rules/__ITEM_CLAUSE__/$item_clause}"
 
 status="[credo] ${rules}"
+
+# --- fresh time + budget line (Fix B: a subagent must not inherit the main
+#     agent's possibly frozen clock/limit values). The time is always current
+#     (local date call). The budget numbers are best-effort from the statusline
+#     per-session cache; absent (e.g. different session_id) -> time only. This
+#     line is marked authoritative so the subagent prefers it over any older
+#     [credo-time]/[limit] value carried in from the main agent's context. ---
+now_line=$(date '+%Y-%m-%d %H:%M (%a), TZ %Z' 2>/dev/null) || now_line=""
+if [[ -n "$now_line" ]]; then
+    now_line=${now_line//\\/}; now_line=${now_line//\"/}
+    now_line=$(printf '%s' "$now_line" | tr -d '[:cntrl:]' 2>/dev/null) || now_line=""
+fi
+if [[ -n "$now_line" ]]; then
+    budget=""
+    if [[ -n "$session_id" ]]; then
+        case "$session_id" in
+            *[!A-Za-z0-9._-]*) : ;;  # unsafe token -> skip cache read
+            *)
+                cache="/tmp/claude-mb-context-cache_${session_id}.json"
+                if [[ -f "$cache" ]]; then
+                    five_h=$(jq -r '.five_hour_pct // ""' "$cache" 2>/dev/null) || five_h=""
+                    weekly=$(jq -r '.seven_day_pct // ""' "$cache" 2>/dev/null) || weekly=""
+                    [[ "$five_h" == "null" ]] && five_h=""
+                    [[ "$weekly" == "null" ]] && weekly=""
+                    [[ -n "$five_h" ]] && budget="${budget} 5h ${five_h}%,"
+                    [[ -n "$weekly" ]] && budget="${budget} Weekly ${weekly}%,"
+                    budget="${budget%,}"
+                fi
+                ;;
+        esac
+    fi
+    now_status="[credo-now] Current local time: ${now_line}."
+    [[ -n "$budget" ]] && now_status="${now_status} Budget:${budget}."
+    now_status="${now_status} Authoritative as of your start - use these, not any older time/budget values inherited from the main agent's context."
+    status="${status}"$'\n'"${now_status}"
+fi
 
 jq -n --arg ctx "$status" \
     '{hookSpecificOutput: {hookEventName: "SubagentStart", additionalContext: $ctx}, suppressOutput: true}' 2>/dev/null

--- a/plugins/credo/hooks/hooks.json
+++ b/plugins/credo/hooks/hooks.json
@@ -21,6 +21,18 @@
         ]
       }
     ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/credo-datetime-inject.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SubagentStart": [
       {
         "hooks": [

--- a/plugins/credo/plugin.yaml
+++ b/plugins/credo/plugin.yaml
@@ -1,6 +1,6 @@
 name: credo
 description: "The mentor framework for Claude Code: a self-contained process layer with per-session modes, a work-item lifecycle with a hard Definition of Done, budget-aware autonomy, visual verification, and safety rules that travel into every subagent"
-version: 0.26.0
+version: 0.27.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/limit/.claude-plugin/plugin.json
+++ b/plugins/limit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "limit",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "description": "Live API usage in Claude Code statusline - colored progress bars, Git info, tokens, session metrics, device tracking, and more",
   "keywords": [
     "usage",

--- a/plugins/limit/README.md
+++ b/plugins/limit/README.md
@@ -121,7 +121,8 @@ All features can be toggled via environment variables. Export them in your shell
 | `CLAUDE_MB_LIMIT_CTX_CACHE` | true | Statusline writes a per-session cache `/tmp/claude-mb-context-cache_${session_id}.json` (window size, limits, cost) |
 | `CLAUDE_MB_LIMIT_INJECT` | true | Inject hook injects a short status line into the agent's context (UserPromptSubmit + PostToolUse) |
 | `CLAUDE_MB_LIMIT_COMPACT_SKILL` | (unset) | The skill the agent should run when a threshold is reached, e.g. `/my-skill`. Empty = status only, no skill named |
-| `CLAUDE_MB_LIMIT_INJECT_INTERVAL` | 180 | Minimum seconds between routine status injects (throttle) |
+| `CLAUDE_MB_LIMIT_INJECT_INTERVAL` | 120 | Minimum seconds between routine status injects (throttle) |
+| `CLAUDE_MB_LIMIT_INJECT_DELTA` | 1 | Minimum change (pct points) in ctx/5h/weekly for a routine re-inject (delta-guard) - quiet phases inject nothing |
 | `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS` | 70,90 | Comma-separated context-fill %% at which the skill hint fires (any count, e.g. `33,66,92`) |
 | `CLAUDE_MB_LIMIT_INJECT_MAX_AGE` | 300 | Ignore the cache (inject nothing) if older than this many seconds - avoids reporting stale numbers |
 
@@ -177,9 +178,12 @@ How it works:
   reads that cache and injects a short status line via `additionalContext` - visible
   to the agent, not flooding the user chat. It skips silently if the cache is missing
   or stale (`CLAUDE_MB_LIMIT_INJECT_MAX_AGE`), so it never reports outdated numbers.
-- It is **throttled** (`CLAUDE_MB_LIMIT_INJECT_INTERVAL`); each threshold in
-  `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS` fires once and adds an action hint to run the
-  skill from `CLAUDE_MB_LIMIT_COMPACT_SKILL`. Thresholds reset after a compact drops the fill.
+- It is **throttled** (`CLAUDE_MB_LIMIT_INJECT_INTERVAL`) and **delta-guarded**
+  (`CLAUDE_MB_LIMIT_INJECT_DELTA`): a routine status is injected only when enough time
+  has passed AND ctx/5h/weekly actually moved, so quiet phases do not grow the context
+  with unchanged lines. Each threshold in `CLAUDE_MB_LIMIT_INJECT_THRESHOLDS` fires once
+  regardless and adds an action hint to run the skill from `CLAUDE_MB_LIMIT_COMPACT_SKILL`.
+  Thresholds reset after a compact drops the fill.
 
 Example injected line (with `CLAUDE_MB_LIMIT_COMPACT_SKILL=/my-skill`):
 

--- a/plugins/limit/plugin.yaml
+++ b/plugins/limit/plugin.yaml
@@ -1,6 +1,6 @@
 name: limit
 description: Live API usage in Claude Code statusline - colored progress bars, Git info, tokens, session metrics, device tracking, and more
-version: 2.26.0
+version: 2.27.0
 author: Marcel Bich
 repository: https://github.com/Marcel-Bich/marcel-bich-claude-marketplace
 

--- a/plugins/limit/scripts/inject-status.sh
+++ b/plugins/limit/scripts/inject-status.sh
@@ -17,9 +17,12 @@
 # context via hookSpecificOutput.additionalContext (visible to the agent, does not
 # flood the user chat).
 #
-# Throttled: a routine status is injected at most every CLAUDE_MB_LIMIT_INJECT_INTERVAL
-# seconds; each threshold in CLAUDE_MB_LIMIT_INJECT_THRESHOLDS fires once and adds an
-# action hint to run CLAUDE_MB_LIMIT_COMPACT_SKILL.
+# Throttled + delta-guarded: a routine status is injected at most every
+# CLAUDE_MB_LIMIT_INJECT_INTERVAL seconds AND only when ctx/5h/weekly actually moved
+# by >= CLAUDE_MB_LIMIT_INJECT_DELTA points since the last inject, so quiet phases do
+# not grow the context with unchanged lines. Each threshold in
+# CLAUDE_MB_LIMIT_INJECT_THRESHOLDS fires once regardless and adds an action hint to
+# run CLAUDE_MB_LIMIT_COMPACT_SKILL.
 #
 # Failure-safe: any problem -> exit 0 with no output. Never disrupt the session.
 
@@ -37,10 +40,16 @@ event=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // "PostToolUse"' 2>/dev/
 [[ "$session_id" == "null" ]] && session_id=""
 [[ "$event" == "null" ]] && event="PostToolUse"
 [[ -n "$session_id" ]] || exit 0
+# Guard against path tricks in the session_id (must be a plain token) before it is
+# interpolated into the /tmp cache/state paths - mirrors the sibling credo hooks.
+case "$session_id" in
+    *[!A-Za-z0-9._-]*) exit 0 ;;
+esac
 
 # --- config (env-overridable) ---
 SKILL="${CLAUDE_MB_LIMIT_COMPACT_SKILL:-}"               # skill to run at thresholds (empty = generic hint only)
-INTERVAL="${CLAUDE_MB_LIMIT_INJECT_INTERVAL:-180}"       # seconds between routine status injects
+INTERVAL="${CLAUDE_MB_LIMIT_INJECT_INTERVAL:-120}"       # seconds between routine status injects
+DELTA="${CLAUDE_MB_LIMIT_INJECT_DELTA:-1}"               # min change (pct points) in ctx/5h/weekly to re-inject a routine status (delta-guard)
 THRESHOLDS="${CLAUDE_MB_LIMIT_INJECT_THRESHOLDS:-70,90}" # comma-separated context-fill % that trigger the skill (e.g. 33,66,92)
 MAX_AGE="${CLAUDE_MB_LIMIT_INJECT_MAX_AGE:-300}"         # ignore the cache if older than this (statusline not rendering)
 
@@ -75,15 +84,31 @@ cost=$(jq -r '.session_cost // "?"' "$meta_file" 2>/dev/null) || cost="?"
 thresh_json=$(printf '%s' "$THRESHOLDS" | jq -R -c 'split(",") | map(gsub("^\\s+|\\s+$";"")) | map(select(test("^[0-9]+(\\.[0-9]+)?$")) | tonumber) | sort' 2>/dev/null)
 [[ -n "$thresh_json" ]] || thresh_json='[]'
 
-# --- throttle + threshold state (per session) ---
+# --- throttle + threshold + delta state (per session) ---
 state_file="/tmp/claude-mb-inject-state_${session_id}.json"
-last_ts=0; fired_json='[]'
+last_ts=0; fired_json='[]'; last_ctx=""; last_5h=""; last_weekly=""
 if [[ -f "$state_file" ]]; then
     last_ts=$(jq -r '.last_ts // 0' "$state_file" 2>/dev/null) || last_ts=0
     fired_json=$(jq -c '.fired // []' "$state_file" 2>/dev/null) || fired_json='[]'
     [[ -n "$fired_json" ]] || fired_json='[]'
+    last_ctx=$(jq -r '.last_ctx // ""' "$state_file" 2>/dev/null) || last_ctx=""
+    last_5h=$(jq -r '.last_5h // ""' "$state_file" 2>/dev/null) || last_5h=""
+    last_weekly=$(jq -r '.last_weekly // ""' "$state_file" 2>/dev/null) || last_weekly=""
+    [[ "$last_ctx" == "null" ]] && last_ctx=""
+    [[ "$last_5h" == "null" ]] && last_5h=""
+    [[ "$last_weekly" == "null" ]] && last_weekly=""
 fi
 [[ "$last_ts" =~ ^[0-9]+$ ]] || last_ts=0
+
+# Delta-guard helper: prints "1" when a routine inject is warranted - either no
+# prior value recorded yet (first routine inject) or any of ctx/5h/weekly moved by
+# >= DELTA points. Non-numeric values (e.g. "?") never trigger and never block.
+delta_exceeded() {
+    awk -v c1="$1" -v l1="$2" -v c2="$3" -v l2="$4" -v c3="$5" -v l3="$6" -v d="$7" '
+        function isnum(x){ return (x ~ /^-?[0-9]+(\.[0-9]+)?$/) }
+        function chk(c,l){ if(!isnum(c)) return 0; if(!isnum(l)) return 1; return ((c-l>=d)||(l-c>=d)) }
+        BEGIN{ if(chk(c1,l1)||chk(c2,l2)||chk(c3,l3)) print "1"; else print "0" }' 2>/dev/null
+}
 
 # Reset: drop fired thresholds the fill has fallen back below (e.g. after a compact)
 fired_json=$(printf '%s' "$fired_json" | jq -c --argjson p "${ctx_pct:-0}" '[.[] | select(. <= $p)]' 2>/dev/null) || fired_json='[]'
@@ -104,15 +129,21 @@ if [[ -n "$to_fire" ]]; then
     # Mark all currently crossed thresholds as fired (so lower ones do not re-fire)
     fired_json=$(printf '%s' "$thresh_json" | jq -c --argjson p "${ctx_pct:-0}" '[.[] | select(. <= $p)]' 2>/dev/null) || fired_json='[]'
 elif [[ $((now - last_ts)) -ge "$INTERVAL" ]]; then
-    do_inject=true
+    # Routine inject only when a value actually moved (or nothing recorded yet),
+    # so quiet phases do not accumulate a status line per interval.
+    if [[ "$(delta_exceeded "$ctx_pct" "$last_ctx" "$five_h" "$last_5h" "$weekly" "$last_weekly" "$DELTA")" == "1" ]]; then
+        do_inject=true
+    fi
 fi
 
 [[ "$do_inject" == "true" ]] || exit 0
 
-# Persist state
+# Persist state (record the just-injected values so the delta-guard compares
+# against what the model last actually saw)
 tmp=$(mktemp 2>/dev/null) && {
     jq -n --argjson last_ts "${now:-0}" --argjson fired "$fired_json" \
-        '{last_ts: $last_ts, fired: $fired}' > "$tmp" 2>/dev/null \
+        --arg last_ctx "${ctx_pct:-}" --arg last_5h "${five_h:-}" --arg last_weekly "${weekly:-}" \
+        '{last_ts: $last_ts, fired: $fired, last_ctx: $last_ctx, last_5h: $last_5h, last_weekly: $last_weekly}' > "$tmp" 2>/dev/null \
         && mv -f "$tmp" "$state_file" 2>/dev/null
     rm -f "$tmp" 2>/dev/null
 }


### PR DESCRIPTION
## Problem

The injected `[credo-time]` and `[limit]` status lines went stale during long autonomous runs and never reached subagents, so the agent (and especially its subagents) reasoned from a frozen clock and outdated limits - e.g. "it is 21:30, let us wait for the reset" at 21:52, or "we are at 91%" when already at 94%.

Root causes:
- `credo-time` fired only on `UserPromptSubmit`, so with no new user prompt the clock froze at the last prompt's value.
- Subagents got only the credo rule block at `SubagentStart` - no time, no limits - and inherited the frozen main-agent values.
- `limit` inject was throttled (180s) and cache-delayed, most irritating right after a reset.

## Changes

- **credo-time** now also fires on `PostToolUse` (throttle 120s + delta-guard on the rendered minute); `UserPromptSubmit` still always injects. Because `PostToolUse` fires only on tool activity, idle waits inject nothing.
- **SubagentStart** primes each subagent with a fresh authoritative time plus best-effort live budget from the statusline cache, marked to override any inherited values.
- **limit inject-status** gains a delta-guard (routine re-inject only when ctx/5h/weekly actually moved) and drops the routine interval 180s -> 120s.
- Adds the missing `session_id` path-traversal guard in `inject-status.sh` (consistency with the two sibling credo hooks; flagged in review).
- Docs (both plugin READMEs + credo guide) and version bumps (credo 0.27.0, limit 2.27.0) updated.

## Test plan

- Syntax check (`bash -n`) passes on all three hook scripts; `hooks.json` is valid JSON.
- UserPromptSubmit path always injects; PostToolUse path injects once then throttles; second call within interval stays silent.
- Delta-guard verified in isolation: with throttle expired, no value change stays silent, a >= 1 point move re-injects.
- SubagentStart emits a fresh `[credo-now]` line with time + budget from the cache.
- Path-traversal guard: a `../../` session_id exits silently (rc 0); a normal session_id still injects.
- Note: the separate wiki repo is not checked out locally and was not updated.